### PR TITLE
Pass scalprum api on mount

### DIFF
--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -62,7 +62,6 @@ describe('scalprum', () => {
         nodeId: 'foo',
       },
     });
-    expect(mount).toHaveBeenCalledTimes(1);
   });
 
   test('should retrive one app by name', () => {
@@ -87,5 +86,26 @@ describe('scalprum', () => {
       { appId: 'app-one', elementId: 'app-one-element', name: 'appOne', rootLocation: '/foo/bar', scriptLocation: '/appOne/url' },
       { appId: 'app-two', elementId: 'app-two-element', name: 'appTwo', rootLocation: '/foo/bar', scriptLocation: '/appTwo/url' },
     ]);
+  });
+
+  test('should pass scalprum object to application on mount', () => {
+    const mount = jest.fn();
+    initialize(mockInititliazeConfig);
+    initializeApp({ ...mockInitializeAppConfig, mount });
+    const app = getApp('foo');
+    app.mount();
+    expect(mount).toHaveBeenCalledWith(window[GLOBAL_NAMESPACE]);
+  });
+
+  test('should pass scalprum object with custom API to application on mount', () => {
+    const mount = jest.fn();
+    initialize(mockInititliazeConfig);
+    initializeApp<{ foo: string }>({ ...mockInitializeAppConfig, mount });
+    const app = getApp<{ foo: string }>('foo');
+    app.mount({ foo: 'bar' });
+    expect(mount).toHaveBeenCalledWith({
+      ...window[GLOBAL_NAMESPACE],
+      foo: 'bar',
+    });
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,8 +89,6 @@ export function initializeApp(configuration: AppInitConfig) {
     update: configuration.update,
     nodeId: configuration.id,
   };
-
-  configuration.mount();
 }
 
 export const getApp = (name: string): Scalplet => window[GLOBAL_NAMESPACE].apps[name];

--- a/packages/test-app/src/appOne.tsx
+++ b/packages/test-app/src/appOne.tsx
@@ -36,7 +36,7 @@ const AppOne = () => {
   );
 };
 
-initializeApp({
+initializeApp<{ foo: string }>({
   id: 'app-one',
   name: 'appOne',
   unmount: () => {
@@ -44,5 +44,10 @@ initializeApp({
     unmountComponentAtNode(document.getElementById('app-one-root')!);
   },
   update: console.log,
-  mount: () => render(<AppOne />, document.getElementById('app-one-root')),
+  mount: (x) => {
+    // just TS check x.foo and scalprum API is type checked;
+    x.foo;
+    x.activeApps;
+    return render(<AppOne />, document.getElementById('app-one-root'));
+  },
 });


### PR DESCRIPTION
wait for #19 
closes #22

### Changes
- removed unnecessary mount call from initializing the app
  - this has to be done by the scaffolding app
  - calling directly in initialize app achieves nothing
- pass an API object as an argument to the mount function
  - passes the whole scalprum object (we may choose to restrict the access later on; we probably don't want apps to have access to other app mounts/unmount methods)
  - object can be extended with custom values