### PR TITLE
Nested routing

### DIFF
--- a/cypress/integration/test-app/nested-react-routing.spec.js
+++ b/cypress/integration/test-app/nested-react-routing.spec.js
@@ -1,0 +1,35 @@
+describe('nested react routing', () => {
+  it('should directly jump to nested route from scaffolding', () => {
+    cy.visit('http://localhost:8123/nested-routing');
+
+    cy.contains('App three nested link from scaffolding').click();
+    cy.get('h2').contains('App three nested route').should('exist');
+  });
+
+  it('should directly acess nested route from URL', () => {
+    cy.visit('http://localhost:8123/nested-routing/app-three/nested');
+
+    cy.get('h2').contains('App three nested route').should('exist');
+  });
+
+  it('should change scalplet location from scaffoling with shared router history', () => {
+    cy.visit('http://localhost:8123/nested-routing/app-three');
+
+    cy.contains('App three nested link from scaffolding').click();
+    cy.get('h2').contains('App three nested route').should('exist');
+  });
+
+  it('should change scalplet location from scaffoling with separate router histories', () => {
+    cy.visit('http://localhost:8123/nested-routing/app-four');
+
+    cy.contains('App four nested link from scaffolding').click();
+    cy.get('h2').contains('App four nested route').should('exist');
+  });
+
+  it('should navigate to a different scalplet nested route', () => {
+    cy.visit('http://localhost:8123/nested-routing/app-four');
+
+    cy.contains('App three nested link from scaffolding').click();
+    cy.get('h2').contains('App three nested route').should('exist');
+  });
+});

--- a/cypress/integration/test-app/react-routing.spec.js
+++ b/cypress/integration/test-app/react-routing.spec.js
@@ -1,6 +1,6 @@
 describe('React routing', () => {
   it('should inject appOne script', () => {
-    cy.visit('http://localhost:8123');
+    cy.visit('http://localhost:8123/basic-routing');
 
     cy.contains('app-one').click();
     cy.get('h1').contains('This is application one').should('exist');

--- a/cypress/integration/test-app/script-injection.spec.js
+++ b/cypress/integration/test-app/script-injection.spec.js
@@ -1,6 +1,6 @@
 describe('React script injection', () => {
   it('should inject appOne script', () => {
-    cy.visit('http://localhost:8123');
+    cy.visit('http://localhost:8123/basic-routing');
 
     /**
      * App one should load

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -1,5 +1,16 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { initialize, GLOBAL_NAMESPACE, initializeApp, getApp, getAppsByRootLocation } from '.';
+import {
+  initialize,
+  GLOBAL_NAMESPACE,
+  initializeApp,
+  getApp,
+  getAppsByRootLocation,
+  getScalprum,
+  setActiveApp,
+  unmountAll,
+  removeActiveApp,
+  unmountAppsFromRoute,
+} from '.';
 
 describe('scalprum', () => {
   const mockInititliazeConfig = {
@@ -108,5 +119,32 @@ describe('scalprum', () => {
       ...window[GLOBAL_NAMESPACE],
       foo: 'bar',
     });
+  });
+
+  test('getScalprum should return the scalprum object', () => {
+    initialize(mockInititliazeConfig);
+    const restult = getScalprum();
+    expect(restult).toEqual(expect.any(Object));
+  });
+
+  test('should call unmount on all active applications', () => {
+    const unmount = jest.fn();
+    initialize(mockInititliazeConfig);
+    initializeApp({ ...mockInitializeAppConfig, name: 'appOne', unmount });
+    initializeApp({ ...mockInitializeAppConfig, name: 'appTwo', unmount });
+
+    setActiveApp('appOne');
+    setActiveApp('appTwo');
+    removeActiveApp('appTwo');
+    unmountAll();
+    expect(unmount).toHaveBeenCalledTimes(1);
+  });
+
+  test('should unmount apps from a route', () => {
+    const unmount = jest.fn();
+    initialize(mockInititliazeConfig);
+    initializeApp({ ...mockInitializeAppConfig, id: 'app-one', name: 'appOne', unmount });
+    initializeApp({ ...mockInitializeAppConfig, id: 'app-two', name: 'appTwo', unmount });
+    unmountAppsFromRoute('/foo/bar');
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,8 @@ declare global {
   }
 }
 
+export const getScalprum = <T = Record<string, unknown>>(): Scalprum<T> => window[GLOBAL_NAMESPACE];
+
 const generateScalpletRoutes = (scalpLets: AppsConfig): { [key: string]: string[] } => {
   const routes: { [key: string]: string[] } = {};
   Object.values(scalpLets).forEach(({ rootLocation, name }) => {
@@ -53,12 +55,13 @@ const generateScalpletRoutes = (scalpLets: AppsConfig): { [key: string]: string[
   return routes;
 };
 
-export const initialize = ({ scalpLets }: { scalpLets: AppsConfig }): void => {
+export const initialize = <T = unknown>({ scalpLets, api }: { scalpLets: AppsConfig; api?: T }): void => {
   window[GLOBAL_NAMESPACE] = {
     apps: {},
     appsMetaData: scalpLets,
     activeApps: {},
     scalpletRoutes: generateScalpletRoutes(scalpLets),
+    ...api,
   };
 };
 
@@ -70,6 +73,14 @@ export const removeActiveApp = (name: string): void => {
 };
 export const unmountAppsFromRoute = (route: string): void => {
   window[GLOBAL_NAMESPACE].scalpletRoutes[route]?.forEach((name: string) => window[GLOBAL_NAMESPACE].apps[name].unmount());
+};
+
+export const unmountAll = (): void => {
+  Object.entries(window[GLOBAL_NAMESPACE].activeApps).filter(([name, isActive]) => {
+    if (isActive) {
+      window[GLOBAL_NAMESPACE].apps[name].unmount();
+    }
+  });
 };
 
 export function initializeApp<T extends Record<string, unknown>>(configuration: AppInitConfig<T>): void {

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -20,6 +20,7 @@
     "start:cjs": "npm run build:cjs -- -w"
   },
   "devDependencies": {
+    "@types/history": "^4.6.2",
     "@types/react": "^16.9.53",
     "@types/react-dom": "^16.9.8",
     "@types/react-router-dom": "^5.1.6"

--- a/packages/react-core/src/scalprum-link.test.tsx
+++ b/packages/react-core/src/scalprum-link.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render, cleanup, getByText } from '@testing-library/react';
+import * as ScalprumCore from '@scalprum/core';
+
+import { ScalprumLink, ScalprumLinkProps } from './scalprum-link';
+
+const DummyComponent: React.ComponentType<ScalprumLinkProps & { initialEntries?: string[] }> = ({ initialEntries, ...props }) => {
+  return (
+    <MemoryRouter initialEntries={initialEntries}>
+      <ScalprumLink id="scalprum-link" {...props}>
+        link
+      </ScalprumLink>
+    </MemoryRouter>
+  );
+};
+describe('<ScalprumLink />', () => {
+  afterEach(() => cleanup());
+
+  test('should not call onmount function', () => {
+    const unmount = jest.fn();
+    const { container } = render(<DummyComponent to="/foo" shouldUnmount={false} unmount={unmount} />);
+    const link = getByText(container, 'link');
+    link.click();
+
+    expect(unmount).not.toHaveBeenCalled();
+  });
+
+  test('should not call onmount function on click', () => {
+    const unmount = jest.fn();
+    const { container } = render(<DummyComponent to="/foo" shouldUnmount unmount={unmount} />);
+    const link = getByText(container, 'link');
+    link.click();
+
+    expect(unmount).toHaveBeenCalledTimes(1);
+  });
+
+  test('should evaluate shouldUnmount function and call onmount function on click', () => {
+    const unmount = jest.fn();
+    const { container } = render(<DummyComponent to="/foo" shouldUnmount={() => true} unmount={unmount} />);
+    const link = getByText(container, 'link');
+    link.click();
+
+    expect(unmount).toHaveBeenCalledTimes(1);
+  });
+
+  test('should evaluate shouldUnmount function and not call onmount function on click', () => {
+    const unmount = jest.fn();
+    const { container } = render(<DummyComponent to="/foo" shouldUnmount={() => false} unmount={unmount} />);
+    const link = getByText(container, 'link');
+    link.click();
+
+    expect(unmount).not.toHaveBeenCalled();
+  });
+
+  test('should call link onClick function', () => {
+    const onClick = jest.fn();
+    const { container } = render(<DummyComponent to="/foo" shouldUnmount={false} onClick={onClick} />);
+    const link = getByText(container, 'link');
+    link.click();
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('should call unmount if pathnames do not match', () => {
+    const unmount = jest.fn();
+    const { container } = render(<DummyComponent initialEntries={['/bar']} to="/foo" unmount={unmount} />);
+    const link = getByText(container, 'link');
+    link.click();
+
+    expect(unmount).toHaveBeenCalledTimes(1);
+  });
+
+  test('should call unmount if router pathname do not match location object pathname', () => {
+    const unmount = jest.fn();
+    const { container } = render(<DummyComponent initialEntries={['/bar']} to={{ pathname: '/foo' }} unmount={unmount} />);
+    const link = getByText(container, 'link');
+    link.click();
+
+    expect(unmount).toHaveBeenCalledTimes(1);
+  });
+
+  test('should not call unmount if pathnames do match', () => {
+    const unmount = jest.fn();
+    const { container } = render(<DummyComponent initialEntries={['/foo']} to="/foo" unmount={unmount} />);
+    const link = getByText(container, 'link');
+    link.click();
+
+    expect(unmount).not.toHaveBeenCalled();
+  });
+
+  test('should call "unmountAppsFromRoute" if no unmount prop was passed', () => {
+    const unmountAppsFromRouteSpy = jest.spyOn(ScalprumCore, 'unmountAppsFromRoute');
+    const unmount = jest.fn();
+    /**
+     * Initialize scalprum
+     */
+    ScalprumCore.initialize({
+      scalpLets: {
+        appOne: {
+          name: 'appOne',
+          rootLocation: '/bar',
+          appId: 'appOne',
+          elementId: 'id',
+          scriptLocation: '/bla',
+        },
+      },
+    });
+
+    ScalprumCore.initializeApp({ id: 'id', name: 'appOne', mount: jest.fn(), unmount, update: jest.fn() });
+    const { container } = render(<DummyComponent initialEntries={['/bar']} to={{ pathname: '/foo' }} />);
+    const link = getByText(container, 'link');
+    link.click();
+
+    expect(unmountAppsFromRouteSpy).toHaveBeenCalledTimes(1);
+    expect(unmountAppsFromRouteSpy).toHaveBeenCalledWith('/bar');
+    expect(unmount).toHaveBeenCalledTimes(1);
+    unmountAppsFromRouteSpy.mockRestore();
+  });
+});

--- a/packages/react-core/src/scalprum-link.tsx
+++ b/packages/react-core/src/scalprum-link.tsx
@@ -1,15 +1,28 @@
 import React from 'react';
 import { unmountAppsFromRoute } from '@scalprum/core';
 import { Link, useLocation, LinkProps } from 'react-router-dom';
+import { History, Location, LocationDescriptor } from 'history';
 
-export const ScalprumLink: React.ComponentType<LinkProps> = ({ to, onClick, ...props }) => {
+export interface ScalprumLinkProps extends LinkProps {
+  shouldUnmount?: boolean | ((pathname: string, to: string | History.LocationDescriptor | ((location: Location) => LocationDescriptor)) => boolean);
+  unmount?: (pathname: string) => void;
+}
+export const ScalprumLink: React.ComponentType<ScalprumLinkProps> = ({ to, onClick, shouldUnmount, unmount, ...props }) => {
   const { pathname } = useLocation();
   return (
     <Link
       onClick={(event) => {
-        const shouldUnmount = (typeof to === 'string' && pathname !== to) || (typeof to === 'object' && pathname !== to.pathname);
-        if (shouldUnmount) {
-          unmountAppsFromRoute(pathname);
+        let unmountResult: boolean | undefined;
+        const unmountFunction = unmount || (() => unmountAppsFromRoute(pathname));
+        if (typeof shouldUnmount === 'undefined') {
+          unmountResult = (typeof to === 'string' && pathname !== to) || (typeof to === 'object' && pathname !== to.pathname);
+        } else if (typeof shouldUnmount === 'boolean') {
+          unmountResult = shouldUnmount;
+        } else if (typeof shouldUnmount === 'function') {
+          unmountResult = shouldUnmount(pathname, to);
+        }
+        if (unmountResult) {
+          unmountFunction(pathname);
         }
         if (onClick) {
           onClick(event);

--- a/packages/react-core/src/scalprum-route.test.tsx
+++ b/packages/react-core/src/scalprum-route.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { ScalprumRoute } from './scalprum-route';
+import { render, cleanup, getByText, act } from '@testing-library/react';
+import * as ScalprumCore from '@scalprum/core';
+import * as Inject from '@scalprum/core/dist/cjs/inject-script';
+import { AppsConfig, GLOBAL_NAMESPACE } from '@scalprum/core';
+
+describe('<ScalprumRoute />', () => {
+  const mockInitScalprumConfig: AppsConfig = {
+    appOne: {
+      name: 'appOne',
+      appId: 'appOne',
+      rootLocation: '/foo',
+      scriptLocation: '/bar.js',
+      elementId: 'id',
+    },
+  };
+  const getAppsByRootLocationSpy = jest.spyOn(ScalprumCore, 'getAppsByRootLocation').mockReturnValue([mockInitScalprumConfig.appOne]);
+  const injectScriptSpy = jest.spyOn(Inject, 'injectScript');
+
+  afterEach(() => {
+    cleanup();
+    window[GLOBAL_NAMESPACE] = undefined;
+    getAppsByRootLocationSpy.mockClear();
+    injectScriptSpy.mockClear();
+  });
+
+  test('should retrieve script location', () => {
+    ScalprumCore.initialize({ scalpLets: mockInitScalprumConfig });
+    render(
+      <MemoryRouter>
+        <ScalprumRoute appName="appOne" elementId="id" path="/foo" />
+      </MemoryRouter>
+    );
+
+    expect(getAppsByRootLocationSpy).toHaveBeenCalledWith('/foo');
+  });
+
+  test('should inject script and mount app if it was not initialized before', async () => {
+    const mount = jest.fn();
+    ScalprumCore.initialize({ scalpLets: mockInitScalprumConfig });
+    injectScriptSpy.mockImplementationOnce(() => {
+      ScalprumCore.initializeApp({ name: 'appOne', mount, unmount: jest.fn(), update: jest.fn(), id: 'appOne' });
+      return Promise.resolve();
+    });
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <ScalprumRoute appName="appOne" elementId="id" path="/foo" />
+        </MemoryRouter>
+      );
+    });
+
+    expect(mount).toHaveBeenCalled();
+    expect(injectScriptSpy).toHaveBeenCalledWith('appOne', '/bar.js');
+  });
+
+  test('should not inject script the app was initialized before', async () => {
+    const mount = jest.fn();
+    ScalprumCore.initialize({ scalpLets: mockInitScalprumConfig });
+    ScalprumCore.initializeApp({ name: 'appOne', mount, unmount: jest.fn(), update: jest.fn(), id: 'appOne' });
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <ScalprumRoute appName="appOne" elementId="id" path="/foo" />
+        </MemoryRouter>
+      );
+    });
+
+    expect(mount).toHaveBeenCalled();
+    expect(injectScriptSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-core/src/scalprum-route.tsx
+++ b/packages/react-core/src/scalprum-route.tsx
@@ -2,13 +2,14 @@ import { getApp, getAppsByRootLocation, injectScript } from '@scalprum/core';
 import React, { Fragment, useEffect } from 'react';
 import { Route, RouteProps } from 'react-router-dom';
 
-export interface ScalprumRouteProps extends RouteProps {
+export interface ScalprumRouteProps<T = Record<string, unknown>> extends RouteProps {
   Placeholder?: React.ComponentType;
   appName: string;
   elementId: string;
   path: string;
+  api?: T;
 }
-export const ScalprumRoute: React.ComponentType<ScalprumRouteProps> = ({ Placeholder = Fragment, elementId, appName, path, ...props }) => {
+export const ScalprumRoute: React.ComponentType<ScalprumRouteProps> = ({ Placeholder = Fragment, elementId, appName, path, api, ...props }) => {
   const { scriptLocation } = getAppsByRootLocation(path as string)?.[0];
   useEffect(() => {
     const app = getApp(appName);
@@ -16,10 +17,10 @@ export const ScalprumRoute: React.ComponentType<ScalprumRouteProps> = ({ Placeho
     if (!app) {
       injectScript(appName, scriptLocation).then(() => {
         const app = getApp(appName);
-        app.mount();
+        app.mount(api);
       });
     } else {
-      app.mount();
+      app.mount(api);
     }
   }, [path]);
 

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@scalprum/core": "*",
     "@scalprum/react-core": "*",
+    "@types/history": "^4.7.8",
     "@types/react": "^16.9.53",
     "@types/react-dom": "^16.9.8",
     "@types/react-router-dom": "^5.1.6",
@@ -21,7 +22,7 @@
     "webpack-dev-server": "^3.9.0"
   },
   "dependencies": {
-    "history": "^5.0.0",
+    "history": "^4.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0"

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -21,6 +21,7 @@
     "webpack-dev-server": "^3.9.0"
   },
   "dependencies": {
+    "history": "^5.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0"

--- a/packages/test-app/src/appFour.tsx
+++ b/packages/test-app/src/appFour.tsx
@@ -1,0 +1,70 @@
+import React, { Fragment, lazy, Suspense, useEffect } from 'react';
+import { render, unmountComponentAtNode } from 'react-dom';
+import { Route, Link, BrowserRouter, useHistory } from 'react-router-dom';
+import { initializeApp } from '@scalprum/core';
+import { History } from 'history';
+
+const AppOneLazyLoaded = lazy(() => import('./app-one-lazy-loaded'));
+
+/**
+ * Nested routing with isolated history.
+ * Outside routing changes must be handled on its own
+ */
+const AppFour: React.ComponentType<{ history: History; basename: string }> = ({ history, basename }) => {
+  const internalHistory = useHistory();
+  useEffect(() => {
+    const historyUnregister = history.listen(({ pathname }) => {
+      console.log({ pathname, internalHistory, includes: pathname.includes(basename) });
+      if (pathname.includes(basename) && internalHistory.location.pathname !== pathname) {
+        internalHistory.push(pathname.replace(new RegExp(`^${basename}`), ''));
+      }
+    });
+    return () => historyUnregister();
+  }, []);
+  return (
+    <Fragment>
+      <ul>
+        <li>
+          <Link to="/">App four top</Link>
+        </li>
+        <li>
+          <Link to="/nested">App four nested route</Link>
+        </li>
+        <li>
+          <Link to="nested-lazy">App four nested lazy route</Link>
+        </li>
+      </ul>
+      <div>
+        <Route path="/">
+          <h1>This is application four</h1>
+        </Route>
+        <Route exact path="/nested">
+          <h2>App four nested route</h2>
+        </Route>
+        <Route exact path="nested-lazy">
+          <Suspense fallback={<div>Loading</div>}>
+            <AppOneLazyLoaded />
+          </Suspense>
+        </Route>
+      </div>
+    </Fragment>
+  );
+};
+
+initializeApp<{ history: History }>({
+  id: 'app-four',
+  name: 'appFour',
+  unmount: () => {
+    console.log('unmounting app four');
+    unmountComponentAtNode(document.getElementById('app-four-root')!);
+  },
+  update: console.log,
+  mount: ({ appsMetaData: { appFour }, history }) => {
+    return render(
+      <BrowserRouter basename={appFour.rootLocation}>
+        <AppFour history={history} basename={appFour.rootLocation} />
+      </BrowserRouter>,
+      document.getElementById('app-four-root')
+    );
+  },
+});

--- a/packages/test-app/src/appOne.tsx
+++ b/packages/test-app/src/appOne.tsx
@@ -5,9 +5,9 @@ import { initializeApp } from '@scalprum/core';
 
 const AppOneLazyLoaded = lazy(() => import('./app-one-lazy-loaded'));
 
-const AppOne = () => {
+const AppOne: React.ComponentType<{ basename: string }> = ({ basename }) => {
   return (
-    <BrowserRouter basename="/app-one">
+    <BrowserRouter basename={basename}>
       <ul>
         <li>
           <Link to="/">App one top</Link>
@@ -44,10 +44,7 @@ initializeApp<{ foo: string }>({
     unmountComponentAtNode(document.getElementById('app-one-root')!);
   },
   update: console.log,
-  mount: (x) => {
-    // just TS check x.foo and scalprum API is type checked;
-    x.foo;
-    x.activeApps;
-    return render(<AppOne />, document.getElementById('app-one-root'));
+  mount: ({ appsMetaData: { appOne } }) => {
+    return render(<AppOne basename={appOne.rootLocation} />, document.getElementById('app-one-root'));
   },
 });

--- a/packages/test-app/src/appThree.tsx
+++ b/packages/test-app/src/appThree.tsx
@@ -1,0 +1,55 @@
+import React, { lazy, Suspense } from 'react';
+import { render, unmountComponentAtNode } from 'react-dom';
+import { Router, Route, Link } from 'react-router-dom';
+import { initializeApp } from '@scalprum/core';
+import { History } from 'history';
+
+const AppOneLazyLoaded = lazy(() => import('./app-one-lazy-loaded'));
+
+/**
+ * Nested routing with shared scaffolding history.
+ * You have to prefix all routes
+ */
+const AppThree: React.ComponentType<{ basename: string; history: History }> = ({ basename, history }) => {
+  return (
+    <Router history={history}>
+      <ul>
+        <li>
+          <Link to={`${basename}`}>App three top</Link>
+        </li>
+        <li>
+          <Link to={`${basename}/nested`}>App three nested route</Link>
+        </li>
+        <li>
+          <Link to={`${basename}/nested-lazy`}>App three nested lazy route</Link>
+        </li>
+      </ul>
+      <div>
+        <Route path={basename}>
+          <h1>This is application three</h1>
+        </Route>
+        <Route exact path={`${basename}/nested`}>
+          <h2>App three nested route</h2>
+        </Route>
+        <Route exact path={`${basename}/nested-lazy`}>
+          <Suspense fallback={<div>Loading</div>}>
+            <AppOneLazyLoaded />
+          </Suspense>
+        </Route>
+      </div>
+    </Router>
+  );
+};
+
+initializeApp<{ history: History }>({
+  id: 'app-three',
+  name: 'appThree',
+  unmount: () => {
+    console.log('unmounting app one');
+    unmountComponentAtNode(document.getElementById('app-three-root')!);
+  },
+  update: console.log,
+  mount: ({ appsMetaData: { appThree }, history }) => {
+    return render(<AppThree history={history} basename={appThree.rootLocation} />, document.getElementById('app-three-root'));
+  },
+});

--- a/packages/test-app/src/basic-routing.tsx
+++ b/packages/test-app/src/basic-routing.tsx
@@ -1,0 +1,35 @@
+import { ScalprumLink, ScalprumRoute, ScalprumState } from '@scalprum/react-core';
+import React from 'react';
+import { Route, Switch } from 'react-router-dom';
+
+const BasicRouting: React.ComponentType<{ scalprum: ScalprumState; routePrefix: string }> = ({ scalprum, routePrefix }) => {
+  return (
+    <div>
+      <h1>Basic routing</h1>
+      <ul>
+        <li>
+          <ScalprumLink to={routePrefix}>Basic routing home</ScalprumLink>
+        </li>
+        {Object.values(scalprum.config)
+          .filter(({ rootLocation }) => rootLocation.includes(routePrefix))
+          .map(({ appId, rootLocation }) => (
+            <li key={appId}>
+              <ScalprumLink to={rootLocation}>{appId}</ScalprumLink>
+            </li>
+          ))}
+      </ul>
+      <Switch>
+        {Object.values(scalprum.config)
+          .filter(({ rootLocation }) => rootLocation.includes(routePrefix))
+          .map(({ name, rootLocation, ...item }) => (
+            <ScalprumRoute key={rootLocation} {...item} appName={name} path={rootLocation} />
+          ))}
+        <Route>
+          <h1>Home</h1>
+        </Route>
+      </Switch>
+    </div>
+  );
+};
+
+export default BasicRouting;

--- a/packages/test-app/src/nested-routing.tsx
+++ b/packages/test-app/src/nested-routing.tsx
@@ -1,0 +1,56 @@
+import { unmountAll } from '@scalprum/core';
+import { ScalprumLink, ScalprumRoute, ScalprumState } from '@scalprum/react-core';
+import React from 'react';
+import { Route, Switch } from 'react-router-dom';
+
+const NestedRouting: React.ComponentType<{ scalprum: ScalprumState; routePrefix: string }> = ({ scalprum, routePrefix }) => {
+  return (
+    <div>
+      <h1>Nested routing</h1>
+      <ul>
+        <li>
+          <ScalprumLink shouldUnmount unmount={() => unmountAll()} to={routePrefix}>
+            Nested routing home
+          </ScalprumLink>
+        </li>
+        <li>
+          <ScalprumLink
+            shouldUnmount={(pathname) => !pathname.includes('/app-three')}
+            unmount={() => unmountAll()}
+            to={`${routePrefix}/app-three/nested`}
+          >
+            App three nested link from scaffolding
+          </ScalprumLink>
+        </li>
+        <li>
+          <ScalprumLink
+            shouldUnmount={(pathname) => !pathname.includes('/app-four')}
+            unmount={() => unmountAll()}
+            to={`${routePrefix}/app-four/nested`}
+          >
+            App four nested link from scaffolding
+          </ScalprumLink>
+        </li>
+        {Object.values(scalprum.config)
+          .filter(({ rootLocation }) => rootLocation.includes(routePrefix))
+          .map(({ appId, rootLocation }) => (
+            <li key={appId}>
+              <ScalprumLink to={rootLocation}>{appId}</ScalprumLink>
+            </li>
+          ))}
+      </ul>
+      <Switch>
+        {Object.values(scalprum.config)
+          .filter(({ rootLocation }) => rootLocation.includes(routePrefix))
+          .map(({ name, rootLocation, ...item }) => (
+            <ScalprumRoute key={rootLocation} {...item} appName={name} path={rootLocation} />
+          ))}
+        <Route>
+          <h1>Home</h1>
+        </Route>
+      </Switch>
+    </div>
+  );
+};
+
+export default NestedRouting;

--- a/packages/test-app/src/scaffolding.tsx
+++ b/packages/test-app/src/scaffolding.tsx
@@ -1,61 +1,83 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import * as ReactDOM from 'react-dom';
-import { AppsConfig } from '@scalprum/core';
-import { useScalprum, ScalprumRoute, ScalprumLink } from '@scalprum/react-core';
-import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { Router, Route, Switch } from 'react-router-dom';
+import { createBrowserHistory, History } from 'history';
+import { AppsConfig, unmountAll } from '@scalprum/core';
+import { useScalprum, ScalprumLink } from '@scalprum/react-core';
+
+import NestedRouting from './nested-routing';
+import BasicRouting from './basic-routing';
 
 window.React = React;
 window.ReactDOM = ReactDOM;
+
+const BASIC_ROUTING = '/basic-routing';
+const NESTED_ROUTING = '/nested-routing';
 
 const config: AppsConfig = {
   appOne: {
     appId: 'app-one',
     elementId: 'app-one-root',
     name: 'appOne',
-    rootLocation: '/app-one',
+    rootLocation: `${BASIC_ROUTING}/app-one`,
     scriptLocation: '/appOne.js',
   },
   appTwo: {
     appId: 'app-two',
     elementId: 'app-two-root',
     name: 'appTwo',
-    rootLocation: '/app-two',
+    rootLocation: `${BASIC_ROUTING}/app-two`,
     scriptLocation: '/appTwo.js',
+  },
+  appThree: {
+    appId: 'app-three',
+    elementId: 'app-three-root',
+    name: 'appThree',
+    rootLocation: `${NESTED_ROUTING}/app-three`,
+    scriptLocation: '/appThree.js',
+  },
+  appFour: {
+    appId: 'app-four',
+    elementId: 'app-four-root',
+    name: 'appFour',
+    rootLocation: `${NESTED_ROUTING}/app-four`,
+    scriptLocation: '/appFour.js',
   },
 };
 
+const history = createBrowserHistory();
+
 const App = () => {
-  const scalprum = useScalprum(config);
-  useEffect(() => {
-    console.log(scalprum);
-  });
+  const scalprum = useScalprum<{ history: History }>(config, { history });
   return (
     <div>
-      <h1>There will be dragons</h1>
-      <BrowserRouter>
+      <Router history={history}>
         <div>
+          <h1>Scafolding routes</h1>
           <ul>
             <li>
-              <ScalprumLink to="/">Home</ScalprumLink>
+              <ScalprumLink shouldUnmount unmount={() => unmountAll()} to={BASIC_ROUTING}>
+                Basic routing
+              </ScalprumLink>
             </li>
-            {Object.values(scalprum.config).map(({ appId, rootLocation }) => (
-              <li key={appId}>
-                <ScalprumLink to={rootLocation}>{appId}</ScalprumLink>
-              </li>
-            ))}
+            <li>
+              <ScalprumLink shouldUnmount unmount={() => unmountAll()} to={NESTED_ROUTING}>
+                Nested routing
+              </ScalprumLink>
+            </li>
           </ul>
         </div>
         <div>
           <Switch>
-            {Object.values(scalprum.config).map(({ name, rootLocation, ...item }) => (
-              <ScalprumRoute key={rootLocation} {...item} appName={name} path={rootLocation} />
-            ))}
-            <Route>
-              <h1>Home</h1>
+            <Route path="/nested-routing">
+              <NestedRouting scalprum={scalprum} routePrefix={NESTED_ROUTING} />
+            </Route>
+            <Route path="/basic-routing">
+              <BasicRouting routePrefix={BASIC_ROUTING} scalprum={scalprum} />
             </Route>
           </Switch>
         </div>
-      </BrowserRouter>
+      </Router>
     </div>
   );
 };

--- a/packages/test-app/webpack.config.js
+++ b/packages/test-app/webpack.config.js
@@ -30,6 +30,8 @@ module.exports = {
   entry: {
     appOne: './src/appOne.tsx',
     appTwo: './src/appTwo.tsx',
+    appThree: './src/appThree.tsx',
+    appFour: './src/appFour.tsx',
     scaffolding: './src/scaffolding.tsx',
   },
   resolve: {
@@ -53,5 +55,8 @@ module.exports = {
   },
   optimization: {
     minimizer: [new TerserPlugin()],
+  },
+  devServer: {
+    historyApiFallback: true,
   },
 };


### PR DESCRIPTION
### Changes
- add nested routing examples
  - one using shared history object (appThree)
  - one using different history objects (appFour)
- update add unmounting mechanism of the Link component
  - This should be considered as the fallback option for unmounting apps. We need to figure out how to reliably handle this from the route component.