### PR TITLE
Handle app unmounting from scalprum route.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalprum/core",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Includes core functions for scalprum scaffolding.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,7 +29,7 @@ export type Scalprum<T = any> = T & {
   };
 };
 export interface Scalplet<T> {
-  mount(api?: T): void;
+  mount<A = void>(api?: T): A;
   unmount(...args: any[]): void;
   update(): void;
   nodeId: string;
@@ -94,7 +94,7 @@ export function initializeApp<T extends Record<string, unknown>>(configuration: 
         ...window[GLOBAL_NAMESPACE],
       };
       setActiveApp(configuration.name);
-      configuration.mount(fullApi);
+      return configuration.mount(fullApi);
     },
     unmount: () => {
       removeActiveApp(configuration.name);

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalprum/react-core",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "React binding for @scalprum/core package.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -26,7 +26,9 @@
     "@types/react-router-dom": "^5.1.6"
   },
   "dependencies": {
-    "@scalprum/core": "*",
+    "@scalprum/core": "*"
+  },
+  "peerDependencies": {
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0"

--- a/packages/react-core/src/scalprum-link.test.tsx
+++ b/packages/react-core/src/scalprum-link.test.tsx
@@ -14,7 +14,10 @@ const DummyComponent: React.ComponentType<ScalprumLinkProps & { initialEntries?:
     </MemoryRouter>
   );
 };
-describe('<ScalprumLink />', () => {
+/**
+ * Scalprum link is deprecated. Unmount handling was moved to scalprum route.
+ */
+describe.skip('<ScalprumLink />', () => {
   afterEach(() => cleanup());
 
   test('should not call onmount function', () => {

--- a/packages/react-core/src/scalprum-link.tsx
+++ b/packages/react-core/src/scalprum-link.tsx
@@ -7,6 +7,9 @@ export interface ScalprumLinkProps extends LinkProps {
   shouldUnmount?: boolean | ((pathname: string, to: string | History.LocationDescriptor | ((location: Location) => LocationDescriptor)) => boolean);
   unmount?: (pathname: string) => void;
 }
+/**
+ * @deprecated since version 0.0.2
+ */
 export const ScalprumLink: React.ComponentType<ScalprumLinkProps> = ({ to, onClick, shouldUnmount, unmount, ...props }) => {
   const { pathname } = useLocation();
   return (
@@ -22,7 +25,7 @@ export const ScalprumLink: React.ComponentType<ScalprumLinkProps> = ({ to, onCli
           unmountResult = shouldUnmount(pathname, to);
         }
         if (unmountResult) {
-          unmountFunction(pathname);
+          // unmountFunction(pathname);
         }
         if (onClick) {
           onClick(event);

--- a/packages/react-core/src/scalprum-route.test.tsx
+++ b/packages/react-core/src/scalprum-route.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { ScalprumRoute } from './scalprum-route';
-import { render, cleanup, getByText, act } from '@testing-library/react';
+import { render, cleanup, act } from '@testing-library/react';
 import * as ScalprumCore from '@scalprum/core';
 import * as Inject from '@scalprum/core/dist/cjs/inject-script';
 import { AppsConfig, GLOBAL_NAMESPACE } from '@scalprum/core';
@@ -28,9 +28,11 @@ describe('<ScalprumRoute />', () => {
 
   test('should retrieve script location', () => {
     ScalprumCore.initialize({ scalpLets: mockInitScalprumConfig });
+    ScalprumCore.initializeApp({ name: 'appOne', id: 'id', mount: jest.fn(), unmount: jest.fn(), update: jest.fn() });
     render(
       <MemoryRouter>
         <ScalprumRoute appName="appOne" elementId="id" path="/foo" />
+        <div id="id"></div>
       </MemoryRouter>
     );
 
@@ -48,6 +50,7 @@ describe('<ScalprumRoute />', () => {
       render(
         <MemoryRouter>
           <ScalprumRoute appName="appOne" elementId="id" path="/foo" />
+          <div id="id"></div>
         </MemoryRouter>
       );
     });
@@ -64,6 +67,7 @@ describe('<ScalprumRoute />', () => {
       render(
         <MemoryRouter>
           <ScalprumRoute appName="appOne" elementId="id" path="/foo" />
+          <div id="id"></div>
         </MemoryRouter>
       );
     });

--- a/packages/react-core/src/scalprum-route.tsx
+++ b/packages/react-core/src/scalprum-route.tsx
@@ -1,5 +1,6 @@
 import { getApp, getAppsByRootLocation, injectScript } from '@scalprum/core';
 import React, { Fragment, useEffect } from 'react';
+import { unmountComponentAtNode, render } from 'react-dom';
 import { Route, RouteProps } from 'react-router-dom';
 
 export interface ScalprumRouteProps<T = Record<string, unknown>> extends RouteProps {
@@ -13,15 +14,23 @@ export const ScalprumRoute: React.ComponentType<ScalprumRouteProps> = ({ Placeho
   const { scriptLocation } = getAppsByRootLocation(path as string)?.[0];
   useEffect(() => {
     const app = getApp(appName);
+    const element = document.getElementById(elementId);
 
     if (!app) {
       injectScript(appName, scriptLocation).then(() => {
         const app = getApp(appName);
-        app.mount(api);
+        const node = app.mount<JSX.Element>(api);
+        render(node, element);
       });
     } else {
-      app.mount(api);
+      const node = app.mount<JSX.Element>(api);
+      render(node, element);
     }
+    return () => {
+      const app = getApp(appName);
+      app.unmount();
+      unmountComponentAtNode(element!);
+    };
   }, [path]);
 
   return (

--- a/packages/test-app/src/appFour.tsx
+++ b/packages/test-app/src/appFour.tsx
@@ -1,10 +1,15 @@
-import React, { Fragment, lazy, Suspense, useEffect } from 'react';
-import { render, unmountComponentAtNode } from 'react-dom';
-import { Route, Link, BrowserRouter, useHistory } from 'react-router-dom';
 import { initializeApp } from '@scalprum/core';
 import { History } from 'history';
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+const { Fragment, lazy, Suspense, useEffect, default: React } = window.React;
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+const { Route, Link, BrowserRouter, useHistory } = window.ReactRouterDOM;
+
 const AppOneLazyLoaded = lazy(() => import('./app-one-lazy-loaded'));
+console.log({ AppOneLazyLoaded });
 
 /**
  * Nested routing with isolated history.
@@ -56,15 +61,13 @@ initializeApp<{ history: History }>({
   name: 'appFour',
   unmount: () => {
     console.log('unmounting app four');
-    unmountComponentAtNode(document.getElementById('app-four-root')!);
   },
   update: console.log,
   mount: ({ appsMetaData: { appFour }, history }) => {
-    return render(
+    return (
       <BrowserRouter basename={appFour.rootLocation}>
         <AppFour history={history} basename={appFour.rootLocation} />
-      </BrowserRouter>,
-      document.getElementById('app-four-root')
+      </BrowserRouter>
     );
   },
 });

--- a/packages/test-app/src/appOne.tsx
+++ b/packages/test-app/src/appOne.tsx
@@ -1,11 +1,14 @@
-import React, { lazy, Suspense } from 'react';
-import { render, unmountComponentAtNode } from 'react-dom';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+const { lazy, Suspense, useState, default: React } = window.React;
 import { BrowserRouter, Route, Link } from 'react-router-dom';
 import { initializeApp } from '@scalprum/core';
 
+console.log(window.React);
 const AppOneLazyLoaded = lazy(() => import('./app-one-lazy-loaded'));
 
 const AppOne: React.ComponentType<{ basename: string }> = ({ basename }) => {
+  const [foo, bar] = useState();
   return (
     <BrowserRouter basename={basename}>
       <ul>
@@ -41,10 +44,9 @@ initializeApp<{ foo: string }>({
   name: 'appOne',
   unmount: () => {
     console.log('unmounting app one');
-    unmountComponentAtNode(document.getElementById('app-one-root')!);
   },
   update: console.log,
   mount: ({ appsMetaData: { appOne } }) => {
-    return render(<AppOne basename={appOne.rootLocation} />, document.getElementById('app-one-root'));
+    return <AppOne basename={appOne.rootLocation} />;
   },
 });

--- a/packages/test-app/src/appThree.tsx
+++ b/packages/test-app/src/appThree.tsx
@@ -1,5 +1,4 @@
 import React, { lazy, Suspense } from 'react';
-import { render, unmountComponentAtNode } from 'react-dom';
 import { Router, Route, Link } from 'react-router-dom';
 import { initializeApp } from '@scalprum/core';
 import { History } from 'history';
@@ -45,11 +44,10 @@ initializeApp<{ history: History }>({
   id: 'app-three',
   name: 'appThree',
   unmount: () => {
-    console.log('unmounting app one');
-    unmountComponentAtNode(document.getElementById('app-three-root')!);
+    console.log('unmounting app three');
   },
   update: console.log,
   mount: ({ appsMetaData: { appThree }, history }) => {
-    return render(<AppThree history={history} basename={appThree.rootLocation} />, document.getElementById('app-three-root'));
+    return <AppThree history={history} basename={appThree.rootLocation} />;
   },
 });

--- a/packages/test-app/src/appTwo.tsx
+++ b/packages/test-app/src/appTwo.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { render, unmountComponentAtNode } from 'react-dom';
 import { initializeApp } from '@scalprum/core';
 
 const AppTwo = () => <h1>This is application two</h1>;
@@ -9,8 +8,7 @@ initializeApp({
   name: 'appTwo',
   unmount: () => {
     console.log('unmounting app two');
-    unmountComponentAtNode(document.getElementById('app-two-root')!);
   },
   update: console.log,
-  mount: () => render(<AppTwo />, document.getElementById('app-two-root')),
+  mount: () => <AppTwo />,
 });

--- a/packages/test-app/src/scaffolding.tsx
+++ b/packages/test-app/src/scaffolding.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Router, Route, Switch } from 'react-router-dom';
+import * as ReactRouterDOM from 'react-router-dom';
 import { createBrowserHistory, History } from 'history';
 import { AppsConfig, unmountAll } from '@scalprum/core';
 import { useScalprum, ScalprumLink } from '@scalprum/react-core';
@@ -8,8 +8,13 @@ import { useScalprum, ScalprumLink } from '@scalprum/react-core';
 import NestedRouting from './nested-routing';
 import BasicRouting from './basic-routing';
 
+const { Router, Route, Switch } = ReactRouterDOM;
+
 window.React = React;
 window.ReactDOM = ReactDOM;
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+window.ReactRouterDOM = ReactRouterDOM;
 
 const BASIC_ROUTING = '/basic-routing';
 const NESTED_ROUTING = '/nested-routing';


### PR DESCRIPTION
### Changes
- call react dom `render` and `unmountComponentAtNode` in scalprum route
  - this will ensure that the application unmounts exactly when it's supposed to
  - on route change via any link
  - on browser back/next events
  - on any browser location history registered by react-router
- ScalprumLink is now deprecated (what a long lifespan!)
- The test app mus be hacked a bit because of external dependencies
  - you can't really mark dependencies as external just for a file :shrug: 
  - tested with chrome 2.0 and hooks and routers work normally.