### PR TITLE
Proper resolve of config function

### DIFF
--- a/packages/react-core/src/__snapshots__/index.test.tsx.snap
+++ b/packages/react-core/src/__snapshots__/index.test.tsx.snap
@@ -27,7 +27,15 @@ exports[`useScalprum should set scalprum feed from async function 1`] = `
     <pre>
       {
   "initialized": true,
-  "config": {}
+  "config": {
+    "appOne": {
+      "name": "appOne",
+      "appId": "foo",
+      "elementId": "element",
+      "rootLocation": "/foo/bar",
+      "scriptLocation": "/some/location"
+    }
+  }
 }
     </pre>
   </div>

--- a/packages/react-core/src/index.test.tsx
+++ b/packages/react-core/src/index.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, cleanup } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 
 import { useScalprum, ScalprumFeed, ScalprumState } from '.';
@@ -28,13 +29,19 @@ describe('useScalprum', () => {
     expect(container).toMatchSnapshot();
   });
 
-  test('should set scalprum feed from function', () => {
-    const { container } = render(<DummyComponent feed={() => config} />);
+  test('should set scalprum feed from function', async () => {
+    let container;
+    await act(async () => {
+      container = render(<DummyComponent feed={() => config} />)?.container;
+    });
     expect(container).toMatchSnapshot();
   });
 
-  test('should set scalprum feed from async function', () => {
-    const { container } = render(<DummyComponent feed={() => Promise.resolve(config)} />);
+  test('should set scalprum feed from async function', async () => {
+    let container;
+    await act(async () => {
+      container = render(<DummyComponent feed={() => Promise.resolve(config)} />)?.container;
+    });
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/react-core/src/index.ts
+++ b/packages/react-core/src/index.ts
@@ -29,16 +29,10 @@ export const useScalprum = <T = Record<string, unknown>>(applicationFeed: Scalpr
     }
 
     if (typeof applicationFeed === 'function') {
-      const result = applicationFeed();
-      if (Object.prototype.hasOwnProperty.call(result, 'then')) {
-        (result as Promise<AppsConfig>).then((config) => {
-          setState((prev) => ({ ...prev, initialized: true, config }));
-          initialize<T>({ scalpLets: config, api });
-        });
-      } else {
-        setState((prev) => ({ ...prev, initialized: true, config: result as AppsConfig }));
-        initialize<T>({ scalpLets: result as AppsConfig, api });
-      }
+      Promise.resolve(applicationFeed()).then((config) => {
+        setState((prev) => ({ ...prev, initialized: true, config: config as AppsConfig }));
+        initialize<T>({ scalpLets: config as AppsConfig, api });
+      });
     }
   }, []);
 


### PR DESCRIPTION
### Functions not properly resolved

When bootstrapping application using `scalprum` it's really convinient to use async function to load data on the fly, unfortunately to improve rendering we don't check for config updates, luckily we can use function for config that can return async call. This is currently incorrectly calculated as check for `then` returns `false` all the time, this PR fixes such issue by passing calculated value to `Promise.resolve` as this will resolve plain and async value.