### PR TITLE
Add new ScalprumComponent to be used when using wb federated moduleS

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -125,16 +125,16 @@ export const getAppsByRootLocation = (pathname: string): AppMetadata[] => {
     }));
 };
 
-export const injectScript = (appName: string, scriptLocation: string): Promise<unknown> => {
+export const injectScript = (appName: string, scriptLocation: string): Promise<[unknown, HTMLScriptElement | undefined]> => {
   let s: HTMLScriptElement | undefined = undefined;
-  const injectionPromise = new Promise((res, rej) => {
+  const injectionPromise: Promise<[unknown, HTMLScriptElement | undefined]> = new Promise((res, rej) => {
     s = document.createElement('script');
     s.src = scriptLocation;
     s.id = appName;
-    setPendingInjection(appName, () => res(name));
+    setPendingInjection(appName, () => res([name, s]));
     s.onerror = (...args) => {
       console.log(args);
-      setPendingInjection(appName, () => rej(args));
+      setPendingInjection(appName, () => rej([args, s]));
     };
   });
   if (typeof s !== 'undefined') {

--- a/packages/react-core/src/TestComponent.tsx
+++ b/packages/react-core/src/TestComponent.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const TestComponent = () => <span>Test</span>;
+
+export default TestComponent;

--- a/packages/react-core/src/__snapshots__/scalprum-component.test.tsx.snap
+++ b/packages/react-core/src/__snapshots__/scalprum-component.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ScalprumComponent /> should render test component 1`] = `
+<div>
+  <span>
+    Test
+  </span>
+</div>
+`;

--- a/packages/react-core/src/async-loader.tsx
+++ b/packages/react-core/src/async-loader.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export interface Container extends Window {
   init: (module: any) => void;
 }
@@ -5,13 +7,26 @@ export interface Container extends Window {
 declare function __webpack_init_sharing__(scope: string): void;
 declare let __webpack_share_scopes__: any;
 
+const ErrorComponent: React.ComponentType<any> = () => {
+  return <span>Error while loading component!</span>;
+};
+
 export function loadComponent(scope: string, module: string) {
   return async (): Promise<{ default: React.ComponentType<any> }> => {
-    await __webpack_init_sharing__('default');
-    const container: Container = (window as { [key: string]: any })[scope];
-    await container.init(__webpack_share_scopes__.default);
-    const factory = await (window as { [key: string]: any })[scope].get(module);
-    const Module: { default: React.ComponentType<any> } = factory();
+    let Module;
+    try {
+      await __webpack_init_sharing__('default');
+      const container: Container = (window as { [key: string]: any })[scope];
+      await container.init(__webpack_share_scopes__.default);
+      const factory = await (window as { [key: string]: any })[scope].get(module);
+      Module = factory();
+    } catch (e) {
+      console.error(e);
+      Module = {
+        default: ErrorComponent,
+      };
+    }
+
     return Module;
   };
 }

--- a/packages/react-core/src/async-loader.tsx
+++ b/packages/react-core/src/async-loader.tsx
@@ -7,11 +7,11 @@ export interface Container extends Window {
 declare function __webpack_init_sharing__(scope: string): void;
 declare let __webpack_share_scopes__: any;
 
-const ErrorComponent: React.ComponentType<any> = () => {
+const DefaultErrorComponent: React.ComponentType<any> = () => {
   return <span>Error while loading component!</span>;
 };
 
-export function loadComponent(scope: string, module: string) {
+export function loadComponent(scope: string, module: string, ErrorComponent: React.Component | undefined) {
   return async (): Promise<{ default: React.ComponentType<any> }> => {
     let Module;
     try {
@@ -23,7 +23,7 @@ export function loadComponent(scope: string, module: string) {
     } catch (e) {
       console.error(e);
       Module = {
-        default: ErrorComponent,
+        default: ErrorComponent || DefaultErrorComponent,
       };
     }
 

--- a/packages/react-core/src/async-loader.tsx
+++ b/packages/react-core/src/async-loader.tsx
@@ -1,0 +1,17 @@
+export interface Container extends Window {
+  init: (module: any) => void;
+}
+
+declare function __webpack_init_sharing__(scope: string): void;
+declare let __webpack_share_scopes__: any;
+
+export function loadComponent(scope: string, module: string) {
+  return async (): Promise<{ default: React.ComponentType<any> }> => {
+    await __webpack_init_sharing__('default');
+    const container: Container = (window as { [key: string]: any })[scope];
+    await container.init(__webpack_share_scopes__.default);
+    const factory = await (window as { [key: string]: any })[scope].get(module);
+    const Module: { default: React.ComponentType<any> } = factory();
+    return Module;
+  };
+}

--- a/packages/react-core/src/async-loader.tsx
+++ b/packages/react-core/src/async-loader.tsx
@@ -11,7 +11,7 @@ const DefaultErrorComponent: React.ComponentType<any> = () => {
   return <span>Error while loading component!</span>;
 };
 
-export function loadComponent(scope: string, module: string, ErrorComponent: React.Component | undefined) {
+export function loadComponent(scope: string, module: string, ErrorComponent: React.ComponentType<any> = DefaultErrorComponent) {
   return async (): Promise<{ default: React.ComponentType<any> }> => {
     let Module;
     try {
@@ -23,7 +23,7 @@ export function loadComponent(scope: string, module: string, ErrorComponent: Rea
     } catch (e) {
       console.error(e);
       Module = {
-        default: ErrorComponent || DefaultErrorComponent,
+        default: ErrorComponent,
       };
     }
 

--- a/packages/react-core/src/index.ts
+++ b/packages/react-core/src/index.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { initialize, AppsConfig } from '@scalprum/core';
 export * from './scalprum-route';
 export * from './scalprum-link';
+export * from './scalprum-component';
 
 /**
  * This is totally random implemenetaion of something that does not exists yet. I needed some react code to setup tests.

--- a/packages/react-core/src/scalprum-component.test.tsx
+++ b/packages/react-core/src/scalprum-component.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import * as asyncComponent from './async-loader';
+import { ScalprumComponent } from './scalprum-component';
+import { render, cleanup, act } from '@testing-library/react';
+import * as ScalprumCore from '@scalprum/core';
+import * as Inject from '@scalprum/core/dist/cjs/inject-script';
+import { AppsConfig, GLOBAL_NAMESPACE } from '@scalprum/core';
+
+describe('<ScalprumComponent />', () => {
+  const mockInitScalprumConfig: AppsConfig = {
+    appOne: {
+      name: 'appOne',
+      appId: 'appOne',
+      rootLocation: '/foo',
+      scriptLocation: '/bar.js',
+      elementId: 'id',
+    },
+  };
+  const getAppsByRootLocationSpy = jest.spyOn(ScalprumCore, 'getAppsByRootLocation').mockReturnValue([mockInitScalprumConfig.appOne]);
+  const injectScriptSpy = jest.spyOn(Inject, 'injectScript');
+  const loadComponentSpy = jest.spyOn(asyncComponent, 'loadComponent').mockReturnValue(() => import('./TestComponent'));
+
+  afterEach(() => {
+    cleanup();
+    window[GLOBAL_NAMESPACE] = undefined;
+    getAppsByRootLocationSpy.mockClear();
+    injectScriptSpy.mockClear();
+  });
+
+  test('should retrieve script location', () => {
+    ScalprumCore.initialize({ scalpLets: mockInitScalprumConfig });
+    ScalprumCore.initializeApp({ name: 'appOne', id: 'id', mount: jest.fn(), unmount: jest.fn(), update: jest.fn() });
+    render(<ScalprumComponent appName="appOne" path="/foo" scope="some" module="test" />);
+
+    expect(getAppsByRootLocationSpy).toHaveBeenCalledWith('/foo');
+  });
+
+  test('should inject script and mount app if it was not initialized before', async () => {
+    const mount = jest.fn();
+    ScalprumCore.initialize({ scalpLets: mockInitScalprumConfig });
+    injectScriptSpy.mockImplementationOnce(() => {
+      ScalprumCore.initializeApp({ name: 'appOne', mount, unmount: jest.fn(), update: jest.fn(), id: 'appOne' });
+      return Promise.resolve();
+    });
+    await act(async () => {
+      render(<ScalprumComponent appName="appOne" path="/foo" scope="some" module="test" />);
+    });
+
+    expect(mount).toHaveBeenCalled();
+    expect(injectScriptSpy).toHaveBeenCalledWith('appOne', '/bar.js');
+  });
+
+  test('should not inject script the app was initialized before', async () => {
+    const mount = jest.fn();
+    ScalprumCore.initialize({ scalpLets: mockInitScalprumConfig });
+    ScalprumCore.initializeApp({ name: 'appOne', mount, unmount: jest.fn(), update: jest.fn(), id: 'appOne' });
+    await act(async () => {
+      render(<ScalprumComponent appName="appOne" path="/foo" scope="some" module="test" />);
+    });
+
+    expect(mount).toHaveBeenCalled();
+    expect(injectScriptSpy).not.toHaveBeenCalled();
+  });
+
+  test('should render test component', async () => {
+    const mount = jest.fn();
+    ScalprumCore.initialize({ scalpLets: mockInitScalprumConfig });
+    ScalprumCore.initializeApp({ name: 'appOne', mount, unmount: jest.fn(), update: jest.fn(), id: 'appOne' });
+    injectScriptSpy.mockImplementationOnce(() => {
+      ScalprumCore.initializeApp({ name: 'appOne', mount, unmount: jest.fn(), update: jest.fn(), id: 'appOne' });
+      return Promise.resolve();
+    });
+    let container;
+    await act(async () => {
+      container = render(<ScalprumComponent appName="appOne" path="/foo" scope="some" module="test" />)?.container;
+    });
+
+    expect(loadComponentSpy).toHaveBeenCalled();
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/react-core/src/scalprum-component.tsx
+++ b/packages/react-core/src/scalprum-component.tsx
@@ -9,6 +9,7 @@ export interface ScalprumComponentProps<T = Record<string, unknown>> {
   api?: T;
   scope: string;
   module: string;
+  ErrorComponent?: React.Component;
 }
 
 export const ScalprumComponent: React.ComponentType<ScalprumComponentProps> = ({
@@ -18,6 +19,7 @@ export const ScalprumComponent: React.ComponentType<ScalprumComponentProps> = ({
   api,
   scope,
   module,
+  ErrorComponent,
   ...props
 }) => {
   const { scriptLocation } = getAppsByRootLocation(path as string)?.[0];
@@ -30,12 +32,12 @@ export const ScalprumComponent: React.ComponentType<ScalprumComponentProps> = ({
       injectScript(appName, scriptLocation).then(([, scriptMountedAt]) => {
         const app = getApp(appName);
         app?.mount<JSX.Element>(api);
-        setComponent(() => React.lazy(loadComponent(scope, module)));
+        setComponent(() => React.lazy(loadComponent(scope, module, ErrorComponent)));
         setMountedAt(() => scriptMountedAt);
       });
     } else {
       app?.mount<JSX.Element>(api);
-      setComponent(() => React.lazy(loadComponent(scope, module)));
+      setComponent(() => React.lazy(loadComponent(scope, module, ErrorComponent)));
     }
     return () => {
       const app = getApp(appName);

--- a/packages/react-core/src/scalprum-component.tsx
+++ b/packages/react-core/src/scalprum-component.tsx
@@ -9,7 +9,7 @@ export interface ScalprumComponentProps<T = Record<string, unknown>> {
   api?: T;
   scope: string;
   module: string;
-  ErrorComponent?: React.Component;
+  ErrorComponent?: React.ComponentType<any>;
 }
 
 export const ScalprumComponent: React.ComponentType<ScalprumComponentProps> = ({

--- a/packages/react-core/src/scalprum-component.tsx
+++ b/packages/react-core/src/scalprum-component.tsx
@@ -1,0 +1,52 @@
+import React, { Fragment, useEffect, Suspense, useState } from 'react';
+import { getApp, getAppsByRootLocation, injectScript } from '@scalprum/core';
+import { loadComponent } from './async-loader';
+
+export interface ScalprumComponentProps<T = Record<string, unknown>> {
+  fallback?: string;
+  appName: string;
+  path: string;
+  api?: T;
+  scope: string;
+  module: string;
+}
+
+export const ScalprumComponent: React.ComponentType<ScalprumComponentProps> = ({
+  fallback = 'loading',
+  appName,
+  path,
+  api,
+  scope,
+  module,
+  ...props
+}) => {
+  const { scriptLocation } = getAppsByRootLocation(path as string)?.[0];
+  const [Component, setComponent] = useState<React.ComponentType<any>>(Fragment);
+  const [mountedAt, setMountedAt] = useState<HTMLScriptElement | undefined>();
+  useEffect(() => {
+    const app = getApp(appName);
+
+    if (!app) {
+      injectScript(appName, scriptLocation).then(([, scriptMountedAt]) => {
+        const app = getApp(appName);
+        app?.mount<JSX.Element>(api);
+        setComponent(() => React.lazy(loadComponent(scope, module)));
+        setMountedAt(() => scriptMountedAt);
+      });
+    } else {
+      app?.mount<JSX.Element>(api);
+      setComponent(() => React.lazy(loadComponent(scope, module)));
+    }
+    return () => {
+      const app = getApp(appName);
+      app?.unmount();
+      mountedAt && document.body.removeChild(mountedAt);
+    };
+  }, [path]);
+
+  return (
+    <Suspense fallback={fallback}>
+      <Component {...props} />
+    </Suspense>
+  );
+};

--- a/packages/react-core/src/scalprum-route.test.tsx
+++ b/packages/react-core/src/scalprum-route.test.tsx
@@ -45,7 +45,7 @@ describe('<ScalprumRoute />', () => {
     injectScriptSpy.mockImplementationOnce(() => {
       ScalprumCore.setPendingInjection('appOne', jest.fn());
       ScalprumCore.initializeApp({ name: 'appOne', mount, unmount: jest.fn(), update: jest.fn(), id: 'appOne' });
-      return Promise.resolve();
+      return Promise.resolve(['', undefined]);
     });
     await act(async () => {
       render(


### PR DESCRIPTION
### Add new component

In order to utilize webpack 5's module federation we need a new component that mounts the required script and shows the correct component. If the component is not found it will show error component as a placeholder.

**Usage**
```JSX
import React from 'react'
import { useScalprum, ScalprumComponent } from '@scalprum/react-core';

const MyApp = () => {
  const scalprum = useScalprum({});
  return <div>
  Some text
  <ScalprumComponent appName="foo" path="./someApp.js" scope="app2" module="./widget" />
</div>
}
```

### Update `mountScript`

Since we are mounting scripts when app is loaded we should also clean after ourselves, I've added a second argument as script location, however we could change this to use callback instead so we don't repeat ourselves.