### PR TITLE
Add manifest processor

### DIFF
--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -29,6 +29,13 @@ describe('scalprum', () => {
         rootLocation: '/foo/bar',
         scriptLocation: '/appTwo/url',
       },
+      appThree: {
+        name: 'appThree',
+        appId: 'app-three',
+        elementId: 'app-three-element',
+        rootLocation: '/foo/bar',
+        manifestLocation: '/appThree/url',
+      },
     },
   };
   const mockInitializeAppConfig = { id: 'foo', name: 'foo', mount: jest.fn(), unmount: jest.fn(), update: jest.fn() };
@@ -46,10 +53,17 @@ describe('scalprum', () => {
       appsMetaData: {
         appOne: { appId: 'app-one', elementId: 'app-one-element', name: 'appOne', rootLocation: '/foo/bar', scriptLocation: '/appOne/url' },
         appTwo: { appId: 'app-two', elementId: 'app-two-element', name: 'appTwo', rootLocation: '/foo/bar', scriptLocation: '/appTwo/url' },
+        appThree: {
+          appId: 'app-three',
+          elementId: 'app-three-element',
+          name: 'appThree',
+          rootLocation: '/foo/bar',
+          manifestLocation: '/appThree/url',
+        },
       },
       pendingInjections: {},
       scalpletRoutes: {
-        '/foo/bar': ['appOne', 'appTwo'],
+        '/foo/bar': ['appOne', 'appTwo', 'appThree'],
       },
       activeApps: {},
     };
@@ -110,6 +124,13 @@ describe('scalprum', () => {
     expect(apps).toEqual([
       { appId: 'app-one', elementId: 'app-one-element', name: 'appOne', rootLocation: '/foo/bar', scriptLocation: '/appOne/url' },
       { appId: 'app-two', elementId: 'app-two-element', name: 'appTwo', rootLocation: '/foo/bar', scriptLocation: '/appTwo/url' },
+      {
+        appId: 'app-three',
+        elementId: 'app-three-element',
+        name: 'appThree',
+        rootLocation: '/foo/bar',
+        manifestLocation: '/appThree/url',
+      },
     ]);
   });
 
@@ -155,15 +176,18 @@ describe('scalprum', () => {
     global[GLOBAL_NAMESPACE].pendingInjections = {
       appOne: jest.fn(),
       appTwo: jest.fn(),
+      appThree: jest.fn(),
     };
     initializeApp({ ...mockInitializeAppConfig, name: 'appOne', unmount });
     initializeApp({ ...mockInitializeAppConfig, name: 'appTwo', unmount });
+    initializeApp({ ...mockInitializeAppConfig, name: 'appThree', unmount });
 
     setActiveApp('appOne');
     setActiveApp('appTwo');
-    removeActiveApp('appTwo');
+    setActiveApp('appThree');
+    removeActiveApp('appThree');
     unmountAll();
-    expect(unmount).toHaveBeenCalledTimes(1);
+    expect(unmount).toHaveBeenCalledTimes(2);
   });
 
   test('should unmount apps from a route', () => {
@@ -173,9 +197,11 @@ describe('scalprum', () => {
     global[GLOBAL_NAMESPACE].pendingInjections = {
       appOne: jest.fn(),
       appTwo: jest.fn(),
+      appThree: jest.fn(),
     };
     initializeApp({ ...mockInitializeAppConfig, id: 'app-one', name: 'appOne', unmount });
     initializeApp({ ...mockInitializeAppConfig, id: 'app-two', name: 'appTwo', unmount });
+    initializeApp({ ...mockInitializeAppConfig, id: 'app-three', name: 'appThree', unmount });
     unmountAppsFromRoute('/foo/bar');
   });
 });

--- a/packages/react-core/src/__snapshots__/scalprum-component.test.tsx.snap
+++ b/packages/react-core/src/__snapshots__/scalprum-component.test.tsx.snap
@@ -7,3 +7,11 @@ exports[`<ScalprumComponent /> should render test component 1`] = `
   </span>
 </div>
 `;
+
+exports[`<ScalprumComponent /> should render test component with manifest 1`] = `
+<div>
+  <span>
+    Test
+  </span>
+</div>
+`;

--- a/packages/react-core/src/scalprum-component.test.tsx
+++ b/packages/react-core/src/scalprum-component.test.tsx
@@ -15,8 +15,19 @@ describe('<ScalprumComponent />', () => {
       elementId: 'id',
     },
   };
+
+  const mockInitScalpumConfigManifest: AppsConfig = {
+    appOne: {
+      name: 'appOne',
+      appId: 'appOne',
+      rootLocation: '/foo',
+      manifestLocation: '/bar.json',
+      elementId: 'id',
+    },
+  };
   const getAppsByRootLocationSpy = jest.spyOn(ScalprumCore, 'getAppsByRootLocation').mockReturnValue([mockInitScalprumConfig.appOne]);
   const injectScriptSpy = jest.spyOn(ScalprumCore, 'injectScript');
+  const processManifestSpy = jest.spyOn(ScalprumCore, 'processManifest');
   const loadComponentSpy = jest.spyOn(asyncComponent, 'loadComponent').mockReturnValue(() => import('./TestComponent'));
 
   afterEach(() => {
@@ -24,10 +35,21 @@ describe('<ScalprumComponent />', () => {
     window[GLOBAL_NAMESPACE] = undefined;
     getAppsByRootLocationSpy.mockClear();
     injectScriptSpy.mockClear();
+    processManifestSpy.mockClear();
   });
 
   test('should retrieve script location', () => {
     ScalprumCore.initialize({ scalpLets: mockInitScalprumConfig });
+    ScalprumCore.setPendingInjection('appOne', jest.fn());
+    ScalprumCore.initializeApp({ name: 'appOne', id: 'id', mount: jest.fn(), unmount: jest.fn(), update: jest.fn() });
+    render(<ScalprumComponent appName="appOne" path="/foo" scope="some" module="test" />);
+
+    expect(getAppsByRootLocationSpy).toHaveBeenCalledWith('/foo');
+  });
+
+  test('should retrieve manifest location', () => {
+    getAppsByRootLocationSpy.mockReturnValueOnce([mockInitScalpumConfigManifest.appOne]);
+    ScalprumCore.initialize({ scalpLets: mockInitScalpumConfigManifest });
     ScalprumCore.setPendingInjection('appOne', jest.fn());
     ScalprumCore.initializeApp({ name: 'appOne', id: 'id', mount: jest.fn(), unmount: jest.fn(), update: jest.fn() });
     render(<ScalprumComponent appName="appOne" path="/foo" scope="some" module="test" />);
@@ -51,6 +73,23 @@ describe('<ScalprumComponent />', () => {
     expect(injectScriptSpy).toHaveBeenCalledWith('appOne', '/bar.js');
   });
 
+  test('should inject manifest and mount app if it was not initialized before', async () => {
+    getAppsByRootLocationSpy.mockReturnValueOnce([mockInitScalpumConfigManifest.appOne]);
+    const mount = jest.fn();
+    ScalprumCore.initialize({ scalpLets: mockInitScalpumConfigManifest });
+    processManifestSpy.mockImplementationOnce(() => {
+      ScalprumCore.setPendingInjection('appOne', jest.fn());
+      ScalprumCore.initializeApp({ name: 'appOne', mount, unmount: jest.fn(), update: jest.fn(), id: 'appOne' });
+      return Promise.resolve([['', undefined]]);
+    });
+    await act(async () => {
+      render(<ScalprumComponent appName="appOne" path="/foo" scope="some" module="test" />);
+    });
+
+    expect(mount).toHaveBeenCalled();
+    expect(processManifestSpy).toHaveBeenCalledWith('/bar.json', 'appOne', 'some', undefined);
+  });
+
   test('should not inject script the app was initialized before', async () => {
     const mount = jest.fn();
     ScalprumCore.initialize({ scalpLets: mockInitScalprumConfig });
@@ -62,6 +101,22 @@ describe('<ScalprumComponent />', () => {
 
     expect(mount).toHaveBeenCalled();
     expect(injectScriptSpy).not.toHaveBeenCalled();
+    expect(processManifestSpy).not.toHaveBeenCalled();
+  });
+
+  test('should not process manifest the app was initialized before', async () => {
+    getAppsByRootLocationSpy.mockReturnValueOnce([mockInitScalpumConfigManifest.appOne]);
+    const mount = jest.fn();
+    ScalprumCore.initialize({ scalpLets: mockInitScalpumConfigManifest });
+    ScalprumCore.setPendingInjection('appOne', jest.fn());
+    ScalprumCore.initializeApp({ name: 'appOne', mount, unmount: jest.fn(), update: jest.fn(), id: 'appOne' });
+    await act(async () => {
+      render(<ScalprumComponent appName="appOne" path="/foo" scope="some" module="test" />);
+    });
+
+    expect(mount).toHaveBeenCalled();
+    expect(processManifestSpy).not.toHaveBeenCalled();
+    expect(injectScriptSpy).not.toHaveBeenCalled();
   });
 
   test('should render test component', async () => {
@@ -71,6 +126,24 @@ describe('<ScalprumComponent />', () => {
       ScalprumCore.setPendingInjection('appOne', jest.fn());
       ScalprumCore.initializeApp({ name: 'appOne', mount, unmount: jest.fn(), update: jest.fn(), id: 'appOne' });
       return Promise.resolve(['', undefined]);
+    });
+    let container;
+    await act(async () => {
+      container = render(<ScalprumComponent appName="appOne" path="/foo" scope="some" module="test" />)?.container;
+    });
+
+    expect(loadComponentSpy).toHaveBeenCalled();
+    expect(container).toMatchSnapshot();
+  });
+
+  test('should render test component with manifest', async () => {
+    getAppsByRootLocationSpy.mockReturnValueOnce([mockInitScalpumConfigManifest.appOne]);
+    const mount = jest.fn();
+    ScalprumCore.initialize({ scalpLets: mockInitScalprumConfig });
+    processManifestSpy.mockImplementationOnce(() => {
+      ScalprumCore.setPendingInjection('appOne', jest.fn());
+      ScalprumCore.initializeApp({ name: 'appOne', mount, unmount: jest.fn(), update: jest.fn(), id: 'appOne' });
+      return Promise.resolve([['', undefined]]);
     });
     let container;
     await act(async () => {

--- a/packages/react-core/src/scalprum-route.tsx
+++ b/packages/react-core/src/scalprum-route.tsx
@@ -17,7 +17,7 @@ export const ScalprumRoute: React.ComponentType<ScalprumRouteProps> = ({ Placeho
     const element = document.getElementById(elementId);
 
     if (!app) {
-      injectScript(appName, scriptLocation).then(() => {
+      injectScript(appName, scriptLocation as string).then(() => {
         const app = getApp(appName);
         const node = app.mount<JSX.Element>(api);
         render(node, element);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,9 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": [
+      "es2019", "dom"
+    ],                             /* Specify library files to be included in the compilation. */
     "allowJs": false,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     "jsx": "react",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
### Manifest location option

In order to fully utilize async loading we want to process manifest location which can contain multiple files to be loaded for component being mounted.

### Note

Similiar approach to component loading can be applied to route, this PR aims to add the option to use manifest and load it in component.