### PR TITLE
Clean up the scalprum component config.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalprum/core",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Includes core functions for scalprum scaffolding.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,9 +1,9 @@
 export const GLOBAL_NAMESPACE = '__scalprum__';
 export interface AppMetadata {
   name: string;
-  appId: string;
-  elementId: string;
-  rootLocation: string;
+  appId?: string;
+  elementId?: string;
+  rootLocation?: string;
   scriptLocation?: string;
   manifestLocation?: string;
 }
@@ -50,9 +50,9 @@ export const getScalprum = <T = Record<string, unknown>>(): Scalprum<T> => windo
 const generateScalpletRoutes = (scalpLets: AppsConfig): { [key: string]: string[] } => {
   const routes: { [key: string]: string[] } = {};
   Object.values(scalpLets).forEach(({ rootLocation, name }) => {
-    if (routes[rootLocation]) {
+    if (rootLocation && routes[rootLocation]) {
       routes[rootLocation].push(name);
-    } else {
+    } else if (rootLocation) {
       routes[rootLocation] = [name];
     }
   });
@@ -116,6 +116,7 @@ export function initializeApp<T extends Record<string, unknown>>(configuration: 
 }
 
 export const getApp = <T = unknown>(name: string): Scalplet<T> => window[GLOBAL_NAMESPACE].apps[name];
+export const getAppData = (name: string): AppMetadata => window[GLOBAL_NAMESPACE].appsMetaData[name];
 
 export const getAppsByRootLocation = (pathname: string): AppMetadata[] => {
   return Object.keys(window[GLOBAL_NAMESPACE].appsMetaData)

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalprum/react-core",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "React binding for @scalprum/core package.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react-core/src/scalprum-component.test.tsx
+++ b/packages/react-core/src/scalprum-component.test.tsx
@@ -25,7 +25,7 @@ describe('<ScalprumComponent />', () => {
       elementId: 'id',
     },
   };
-  const getAppsByRootLocationSpy = jest.spyOn(ScalprumCore, 'getAppsByRootLocation').mockReturnValue([mockInitScalprumConfig.appOne]);
+  const getAppDataSpy = jest.spyOn(ScalprumCore, 'getAppData').mockReturnValue(mockInitScalprumConfig.appOne);
   const injectScriptSpy = jest.spyOn(ScalprumCore, 'injectScript');
   const processManifestSpy = jest.spyOn(ScalprumCore, 'processManifest');
   const loadComponentSpy = jest.spyOn(asyncComponent, 'loadComponent').mockReturnValue(() => import('./TestComponent'));
@@ -33,7 +33,7 @@ describe('<ScalprumComponent />', () => {
   afterEach(() => {
     cleanup();
     window[GLOBAL_NAMESPACE] = undefined;
-    getAppsByRootLocationSpy.mockClear();
+    getAppDataSpy.mockClear();
     injectScriptSpy.mockClear();
     processManifestSpy.mockClear();
   });
@@ -42,19 +42,19 @@ describe('<ScalprumComponent />', () => {
     ScalprumCore.initialize({ scalpLets: mockInitScalprumConfig });
     ScalprumCore.setPendingInjection('appOne', jest.fn());
     ScalprumCore.initializeApp({ name: 'appOne', id: 'id', mount: jest.fn(), unmount: jest.fn(), update: jest.fn() });
-    render(<ScalprumComponent appName="appOne" path="/foo" scope="some" module="test" />);
+    render(<ScalprumComponent appName="appOne" scope="some" module="test" />);
 
-    expect(getAppsByRootLocationSpy).toHaveBeenCalledWith('/foo');
+    expect(getAppDataSpy).toHaveBeenCalledWith('appOne');
   });
 
   test('should retrieve manifest location', () => {
-    getAppsByRootLocationSpy.mockReturnValueOnce([mockInitScalpumConfigManifest.appOne]);
+    getAppDataSpy.mockReturnValueOnce(mockInitScalpumConfigManifest.appOne);
     ScalprumCore.initialize({ scalpLets: mockInitScalpumConfigManifest });
     ScalprumCore.setPendingInjection('appOne', jest.fn());
     ScalprumCore.initializeApp({ name: 'appOne', id: 'id', mount: jest.fn(), unmount: jest.fn(), update: jest.fn() });
-    render(<ScalprumComponent appName="appOne" path="/foo" scope="some" module="test" />);
+    render(<ScalprumComponent appName="appOne" scope="some" module="test" />);
 
-    expect(getAppsByRootLocationSpy).toHaveBeenCalledWith('/foo');
+    expect(getAppDataSpy).toHaveBeenCalledWith('appOne');
   });
 
   test('should inject script and mount app if it was not initialized before', async () => {
@@ -66,7 +66,7 @@ describe('<ScalprumComponent />', () => {
       return Promise.resolve(['', undefined]);
     });
     await act(async () => {
-      render(<ScalprumComponent appName="appOne" path="/foo" scope="some" module="test" />);
+      render(<ScalprumComponent appName="appOne" scope="some" module="test" />);
     });
 
     expect(mount).toHaveBeenCalled();
@@ -74,7 +74,7 @@ describe('<ScalprumComponent />', () => {
   });
 
   test('should inject manifest and mount app if it was not initialized before', async () => {
-    getAppsByRootLocationSpy.mockReturnValueOnce([mockInitScalpumConfigManifest.appOne]);
+    getAppDataSpy.mockReturnValueOnce(mockInitScalpumConfigManifest.appOne);
     const mount = jest.fn();
     ScalprumCore.initialize({ scalpLets: mockInitScalpumConfigManifest });
     processManifestSpy.mockImplementationOnce(() => {
@@ -83,7 +83,7 @@ describe('<ScalprumComponent />', () => {
       return Promise.resolve([['', undefined]]);
     });
     await act(async () => {
-      render(<ScalprumComponent appName="appOne" path="/foo" scope="some" module="test" />);
+      render(<ScalprumComponent appName="appOne" scope="some" module="test" />);
     });
 
     expect(mount).toHaveBeenCalled();
@@ -96,7 +96,7 @@ describe('<ScalprumComponent />', () => {
     ScalprumCore.setPendingInjection('appOne', jest.fn());
     ScalprumCore.initializeApp({ name: 'appOne', mount, unmount: jest.fn(), update: jest.fn(), id: 'appOne' });
     await act(async () => {
-      render(<ScalprumComponent appName="appOne" path="/foo" scope="some" module="test" />);
+      render(<ScalprumComponent appName="appOne" scope="some" module="test" />);
     });
 
     expect(mount).toHaveBeenCalled();
@@ -105,13 +105,13 @@ describe('<ScalprumComponent />', () => {
   });
 
   test('should not process manifest the app was initialized before', async () => {
-    getAppsByRootLocationSpy.mockReturnValueOnce([mockInitScalpumConfigManifest.appOne]);
+    getAppDataSpy.mockReturnValueOnce(mockInitScalpumConfigManifest.appOne);
     const mount = jest.fn();
     ScalprumCore.initialize({ scalpLets: mockInitScalpumConfigManifest });
     ScalprumCore.setPendingInjection('appOne', jest.fn());
     ScalprumCore.initializeApp({ name: 'appOne', mount, unmount: jest.fn(), update: jest.fn(), id: 'appOne' });
     await act(async () => {
-      render(<ScalprumComponent appName="appOne" path="/foo" scope="some" module="test" />);
+      render(<ScalprumComponent appName="appOne" scope="some" module="test" />);
     });
 
     expect(mount).toHaveBeenCalled();
@@ -129,7 +129,7 @@ describe('<ScalprumComponent />', () => {
     });
     let container;
     await act(async () => {
-      container = render(<ScalprumComponent appName="appOne" path="/foo" scope="some" module="test" />)?.container;
+      container = render(<ScalprumComponent appName="appOne" scope="some" module="test" />)?.container;
     });
 
     expect(loadComponentSpy).toHaveBeenCalled();
@@ -137,7 +137,7 @@ describe('<ScalprumComponent />', () => {
   });
 
   test('should render test component with manifest', async () => {
-    getAppsByRootLocationSpy.mockReturnValueOnce([mockInitScalpumConfigManifest.appOne]);
+    getAppDataSpy.mockReturnValueOnce(mockInitScalpumConfigManifest.appOne);
     const mount = jest.fn();
     ScalprumCore.initialize({ scalpLets: mockInitScalprumConfig });
     processManifestSpy.mockImplementationOnce(() => {
@@ -147,7 +147,7 @@ describe('<ScalprumComponent />', () => {
     });
     let container;
     await act(async () => {
-      container = render(<ScalprumComponent appName="appOne" path="/foo" scope="some" module="test" />)?.container;
+      container = render(<ScalprumComponent appName="appOne" scope="some" module="test" />)?.container;
     });
 
     expect(loadComponentSpy).toHaveBeenCalled();

--- a/packages/react-core/src/scalprum-component.tsx
+++ b/packages/react-core/src/scalprum-component.tsx
@@ -1,22 +1,20 @@
 import React, { Fragment, useEffect, Suspense, useState } from 'react';
-import { getApp, getAppsByRootLocation, injectScript, processManifest } from '@scalprum/core';
+import { getApp, getAppData, injectScript, processManifest } from '@scalprum/core';
 import { loadComponent } from './async-loader';
 
 export interface ScalprumComponentProps<T = Record<string, unknown>> {
   fallback?: string;
   appName: string;
-  path: string;
   api?: T;
   scope: string;
   module: string;
-  ErrorComponent?: React.ComponentType<any>;
+  ErrorComponent?: React.ComponentType;
   processor?: (item: any) => string;
 }
 
 export const ScalprumComponent: React.ComponentType<ScalprumComponentProps> = ({
   fallback = 'loading',
   appName,
-  path,
   api,
   scope,
   module,
@@ -24,7 +22,7 @@ export const ScalprumComponent: React.ComponentType<ScalprumComponentProps> = ({
   processor,
   ...props
 }) => {
-  const { scriptLocation, manifestLocation } = getAppsByRootLocation(path as string)?.[0];
+  const { scriptLocation, manifestLocation } = getAppData(appName);
   const [Component, setComponent] = useState<React.ComponentType<any>>(Fragment);
   const [mountedAt, setMountedAt] = useState<HTMLScriptElement | HTMLScriptElement[] | undefined>();
   useEffect(() => {
@@ -57,7 +55,7 @@ export const ScalprumComponent: React.ComponentType<ScalprumComponentProps> = ({
         Array.isArray(mountedAt) ? mountedAt.forEach((mounted) => document.body.removeChild(mounted)) : document.body.removeChild(mountedAt);
       }
     };
-  }, [path]);
+  }, []);
 
   return (
     <Suspense fallback={fallback}>

--- a/packages/test-app/src/appFour.tsx
+++ b/packages/test-app/src/appFour.tsx
@@ -66,7 +66,7 @@ initializeApp<{ history: History }>({
   mount: ({ appsMetaData: { appFour }, history }) => {
     return (
       <BrowserRouter basename={appFour.rootLocation}>
-        <AppFour history={history} basename={appFour.rootLocation} />
+        <AppFour history={history} basename={appFour.rootLocation!} />
       </BrowserRouter>
     );
   },

--- a/packages/test-app/src/appOne.tsx
+++ b/packages/test-app/src/appOne.tsx
@@ -47,6 +47,6 @@ initializeApp<{ foo: string }>({
   },
   update: console.log,
   mount: ({ appsMetaData: { appOne } }) => {
-    return <AppOne basename={appOne.rootLocation} />;
+    return <AppOne basename={appOne.rootLocation!} />;
   },
 });

--- a/packages/test-app/src/appThree.tsx
+++ b/packages/test-app/src/appThree.tsx
@@ -48,6 +48,6 @@ initializeApp<{ history: History }>({
   },
   update: console.log,
   mount: ({ appsMetaData: { appThree }, history }) => {
-    return <AppThree history={history} basename={appThree.rootLocation} />;
+    return <AppThree history={history} basename={appThree.rootLocation!} />;
   },
 });

--- a/packages/test-app/src/basic-routing.tsx
+++ b/packages/test-app/src/basic-routing.tsx
@@ -1,6 +1,8 @@
+import { AppMetadata } from '@scalprum/core';
 import { ScalprumLink, ScalprumRoute, ScalprumState } from '@scalprum/react-core';
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
+import { Full } from './helpers';
 
 const BasicRouting: React.ComponentType<{ scalprum: ScalprumState; routePrefix: string }> = ({ scalprum, routePrefix }) => {
   return (
@@ -10,7 +12,7 @@ const BasicRouting: React.ComponentType<{ scalprum: ScalprumState; routePrefix: 
         <li>
           <ScalprumLink to={routePrefix}>Basic routing home</ScalprumLink>
         </li>
-        {Object.values(scalprum.config)
+        {Object.values(scalprum.config as { [key: string]: Full<AppMetadata> })
           .filter(({ rootLocation }) => rootLocation.includes(routePrefix))
           .map(({ appId, rootLocation }) => (
             <li key={appId}>
@@ -19,7 +21,7 @@ const BasicRouting: React.ComponentType<{ scalprum: ScalprumState; routePrefix: 
           ))}
       </ul>
       <Switch>
-        {Object.values(scalprum.config)
+        {Object.values(scalprum.config as { [key: string]: Full<AppMetadata> })
           .filter(({ rootLocation }) => rootLocation.includes(routePrefix))
           .map(({ name, rootLocation, ...item }) => (
             <ScalprumRoute key={rootLocation} {...item} appName={name} path={rootLocation} />

--- a/packages/test-app/src/helpers.d.ts
+++ b/packages/test-app/src/helpers.d.ts
@@ -1,0 +1,3 @@
+export type Full<T> = {
+  [P in keyof T]-?: T[P];
+};

--- a/packages/test-app/src/nested-routing.tsx
+++ b/packages/test-app/src/nested-routing.tsx
@@ -1,7 +1,8 @@
-import { unmountAll } from '@scalprum/core';
+import { AppMetadata, unmountAll } from '@scalprum/core';
 import { ScalprumLink, ScalprumRoute, ScalprumState } from '@scalprum/react-core';
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
+import { Full } from './helpers';
 
 const NestedRouting: React.ComponentType<{ scalprum: ScalprumState; routePrefix: string }> = ({ scalprum, routePrefix }) => {
   return (
@@ -31,7 +32,7 @@ const NestedRouting: React.ComponentType<{ scalprum: ScalprumState; routePrefix:
             App four nested link from scaffolding
           </ScalprumLink>
         </li>
-        {Object.values(scalprum.config)
+        {Object.values(scalprum.config as { [key: string]: Full<AppMetadata> })
           .filter(({ rootLocation }) => rootLocation.includes(routePrefix))
           .map(({ appId, rootLocation }) => (
             <li key={appId}>
@@ -40,7 +41,7 @@ const NestedRouting: React.ComponentType<{ scalprum: ScalprumState; routePrefix:
           ))}
       </ul>
       <Switch>
-        {Object.values(scalprum.config)
+        {Object.values(scalprum.config as { [key: string]: Full<AppMetadata> })
           .filter(({ rootLocation }) => rootLocation.includes(routePrefix))
           .map(({ name, rootLocation, ...item }) => (
             <ScalprumRoute key={rootLocation} {...item} appName={name} path={rootLocation} />


### PR DESCRIPTION
This will reduce the number of required configurations for `ScalprumComponent` to:

```jsx
// config
  const config = {
    advisor: {
      name: 'advisor',
      manifestLocation: `${window.location.origin}/apps/advisor/fed-mods.json`,
    },
  };

// component
<ScalprumComponent appName="advisor" module="./RootApp" scope="advisor" />
```