### PR TITLE
Add error boundary around scalprum component.

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalprum/react-core",
-  "version": "0.0.7",
+  "version": "0.0.10",
   "description": "React binding for @scalprum/core package.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react-core/src/scalprum-component.test.tsx
+++ b/packages/react-core/src/scalprum-component.test.tsx
@@ -220,7 +220,7 @@ describe('<ScalprumComponent />', () => {
       appName: 'appOne',
       scope: 'some',
       module: 'test',
-      ErrorComponent: () => <h1>Custom error component</h1>,
+      ErrorComponent: <h1>Custom error component</h1>,
     };
     let container;
     await act(async () => {


### PR DESCRIPTION
### Changes
- Add an error boundary around the whole scalprum component
  - prevents any runtime crashes caused by incorrect module load and renders error component
- change ErrorComponent to react node
  - this will prevent issues caused by passing anonymous components
  - it is still converted to a component type for script loading related errors so it can be passed as a module