### PR TITLE
Change how cjs is built to use project instead build

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalprum/core",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "description": "Includes core functions for scalprum scaffolding.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "npm run build:cjs && npm run build:esm && npm run build:typings",
     "build:esm": "tsc",
-    "build:cjs": "tsc --build tsconfig.cjs.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:typings": "node ../../scripts/create-typings.js",
     "start:esm": "npm run build:esm -- -w",
     "start:cjs": "npm run build:cjs -- -w"

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalprum/react-core",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "React binding for @scalprum/core package.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "npm run build:cjs && npm run build:esm && npm run build:typings",
     "build:esm": "tsc",
-    "build:cjs": "tsc --build tsconfig.cjs.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:typings": "node ../../scripts/create-typings.js",
     "start:esm": "npm run build:esm -- -w",
     "start:cjs": "npm run build:cjs -- -w"


### PR DESCRIPTION
### Fix how cjs is build

There was an error when running build for CJS since it didn't register updated nested files. I've dug a bit and found out that we should use `--project`/`-p` instead `--build`