### PR TITLE
Improve loading component rendering.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@testing-library/jest-dom": "^5.11.4",
         "@testing-library/react": "^11.1.0",
         "@types/jest": "^26.0.15",
+        "@types/lodash": "^4.14.168",
         "@types/react": "^16.9.53",
         "@types/react-router-dom": "^5.1.6",
         "@typescript-eslint/eslint-plugin": "^4.6.0",
@@ -5642,6 +5643,12 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.168",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
       "dev": true
     },
     "node_modules/@types/minimatch": {
@@ -28789,6 +28796,12 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.168",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
       "dev": true
     },
     "@types/minimatch": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@types/jest": "^26.0.15",
+    "@types/lodash": "^4.14.168",
     "@types/react": "^16.9.53",
     "@types/react-router-dom": "^5.1.6",
     "@typescript-eslint/eslint-plugin": "^4.6.0",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalprum/react-core",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "React binding for @scalprum/core package.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -26,7 +26,8 @@
     "@types/react-router-dom": "^5.1.6"
   },
   "dependencies": {
-    "@scalprum/core": "*"
+    "@scalprum/core": "*",
+    "lodash": "^4.17.0"
   },
   "peerDependencies": {
     "react": ">=16.8.0",

--- a/packages/react-core/src/__snapshots__/scalprum-component.test.tsx.snap
+++ b/packages/react-core/src/__snapshots__/scalprum-component.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`<ScalprumComponent /> should render error component 1`] = `
 exports[`<ScalprumComponent /> should render fallback component 1`] = `
 <div>
   <h1>
-    Loading
+    Suspense fallback
   </h1>
 </div>
 `;
@@ -24,7 +24,11 @@ exports[`<ScalprumComponent /> should render fallback component 2`] = `
 </div>
 `;
 
-exports[`<ScalprumComponent /> should render test component 1`] = `<div />`;
+exports[`<ScalprumComponent /> should render test component 1`] = `
+<div>
+  loading
+</div>
+`;
 
 exports[`<ScalprumComponent /> should render test component 2`] = `
 <div>


### PR DESCRIPTION
### Changes
- remove loading component and re-use fallback prop instead

Why? When switching between fallback and LoadingComponent we create a new instance of the loader. That means that any animation, sequence, etc. will be re-started resulting in weird flashing. (restarting spinner cycle)

Using the same React.Node fallback in every place will ensure that we use the same node instance for continuous animations and a smoother loading state. There is also an undefined state for the Component instead of the Loading component. We could use wrapper fallback here but that also resets the render cycle.