### PR TITLE
bump core dependency version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalprum/core",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Includes core functions for scalprum scaffolding.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalprum/react-core",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "React binding for @scalprum/core package.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -26,7 +26,7 @@
     "@types/react-router-dom": "^5.1.6"
   },
   "dependencies": {
-    "@scalprum/core": "*",
+    "@scalprum/core": "^0.0.11",
     "lodash": "^4.17.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
The yarn was installing v0.0.3 of the core because the rest was tagged as a beta. The old version does not have some functions.