### PR TITLE
fix(esm): use esm module build output

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "npm run build:cjs && npm run build:esm && npm run build:typings",
-    "build:esm": "tsc",
+    "build:esm": "tsc --module es2015 --target es5",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:typings": "node ../../scripts/create-typings.js",
     "start:esm": "npm run build:esm -- -w",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -13,7 +13,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "npm run build:cjs && npm run build:esm && npm run build:typings",
-    "build:esm": "tsc",
+    "build:esm": "tsc --module es2015 --target es5",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:typings": "node ../../scripts/create-typings.js",
     "start:esm": "npm run build:esm -- -w",


### PR DESCRIPTION
We were not actually building esm module using `build:esm` commands.