### PR TITLE
fix(react-core): update scalprum provider on API change

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalprum/react-core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "React binding for @scalprum/core package.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
The scalprum context was only updated on config changes but was ignoring the API changes. Therefore the `useScalprum` hook was not updating correctly.