### PR TITLE
Add generic async loader for loading non-react modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18615,8 +18615,6 @@
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
       "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -19789,8 +19787,6 @@
       "version": "0.20.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
       "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -23988,45 +23984,6 @@
         "react-router-dom": "^5.2.0"
       }
     },
-    "packages/react-core/node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "packages/react-core/node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
-    "packages/react-core/node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
     "packages/test-app": {
       "name": "my-webpack-project",
       "version": "1.0.0",
@@ -24047,42 +24004,6 @@
         "webpack": "^4.41.3",
         "webpack-cli": "^3.3.10",
         "webpack-dev-server": "^3.9.0"
-      }
-    },
-    "packages/test-app/node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "packages/test-app/node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
-    "packages/test-app/node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
       }
     }
   },
@@ -28430,41 +28351,6 @@
         "@types/react-dom": "^16.9.8",
         "@types/react-router-dom": "^5.1.6",
         "lodash": "^4.17.0"
-      },
-      "dependencies": {
-        "react": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-          "peer": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "react-dom": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-          "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-          "peer": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.19.1"
-          }
-        },
-        "scheduler": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-          "peer": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
       }
     },
     "@sinonjs/commons": {
@@ -37803,37 +37689,6 @@
         "webpack": "^4.41.3",
         "webpack-cli": "^3.3.10",
         "webpack-dev-server": "^3.9.0"
-      },
-      "dependencies": {
-        "react": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "react-dom": {
-          "version": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-          "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.19.1"
-          }
-        },
-        "scheduler": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
       }
     },
     "mz": {
@@ -39180,8 +39035,6 @@
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
       "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
-      "dev": true,
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -40128,8 +39981,6 @@
       "version": "0.20.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
       "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
-      "dev": true,
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18615,6 +18615,8 @@
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
       "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -19787,6 +19789,8 @@
       "version": "0.20.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
       "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -23984,6 +23988,45 @@
         "react-router-dom": "^5.2.0"
       }
     },
+    "packages/react-core/node_modules/react": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/react-core/node_modules/react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0"
+      }
+    },
+    "packages/react-core/node_modules/scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
     "packages/test-app": {
       "name": "my-webpack-project",
       "version": "1.0.0",
@@ -24004,6 +24047,42 @@
         "webpack": "^4.41.3",
         "webpack-cli": "^3.3.10",
         "webpack-dev-server": "^3.9.0"
+      }
+    },
+    "packages/test-app/node_modules/react": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/test-app/node_modules/react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0"
+      }
+    },
+    "packages/test-app/node_modules/scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     }
   },
@@ -28351,6 +28430,41 @@
         "@types/react-dom": "^16.9.8",
         "@types/react-router-dom": "^5.1.6",
         "lodash": "^4.17.0"
+      },
+      "dependencies": {
+        "react": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+          "peer": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "react-dom": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+          "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+          "peer": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.19.1"
+          }
+        },
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "peer": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "@sinonjs/commons": {
@@ -37689,6 +37803,37 @@
         "webpack": "^4.41.3",
         "webpack-cli": "^3.3.10",
         "webpack-dev-server": "^3.9.0"
+      },
+      "dependencies": {
+        "react": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "react-dom": {
+          "version": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+          "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.19.1"
+          }
+        },
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "mz": {
@@ -39035,6 +39180,8 @@
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
       "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -39981,6 +40128,8 @@
       "version": "0.20.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
       "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,11 @@ export interface Scalplet<T> {
 export interface Container extends Window {
   init: (module: any) => void;
 }
+
+export interface IModule {
+  default: any;
+}
+
 declare global {
   // eslint-disable-next-line no-unused-vars
   interface Window {
@@ -182,7 +187,7 @@ export async function processManifest(
   );
 }
 
-export async function asyncLoader(scope: string, module: string): Promise<{ default: any }> {
+export async function asyncLoader(scope: string, module: string): Promise<IModule> {
   if (typeof scope === 'undefined' || scope.length === 0) {
     throw new Error("Scope can't be undefined or empty");
   }
@@ -191,7 +196,7 @@ export async function asyncLoader(scope: string, module: string): Promise<{ defa
   }
 
   if (!module.startsWith('./')) {
-    console.warn(`Your module ${module} doesn't start with './' this indicates and error`);
+    console.warn(`Your module ${module} doesn't start with './' this indicates an error`);
   }
 
   await __webpack_init_sharing__('default');

--- a/packages/react-core/src/async-loader.tsx
+++ b/packages/react-core/src/async-loader.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-
-export interface Container extends Window {
-  init: (module: any) => void;
-}
-
-declare function __webpack_init_sharing__(scope: string): void;
-declare let __webpack_share_scopes__: any;
+import { asyncLoader } from '@scalprum/core';
 
 const DefaultErrorComponent: React.ComponentType<any> = () => {
   return <span>Error while loading component!</span>;
@@ -15,11 +9,7 @@ export function loadComponent(scope: string, module: string, ErrorComponent: Rea
   return async (): Promise<{ default: React.ComponentType<any> }> => {
     let Module;
     try {
-      await __webpack_init_sharing__('default');
-      const container: Container = (window as { [key: string]: any })[scope];
-      await container.init(__webpack_share_scopes__.default);
-      const factory = await (window as { [key: string]: any })[scope].get(module);
-      Module = factory();
+      Module = await asyncLoader(scope, module);
     } catch (e) {
       console.error(e);
       Module = {

--- a/packages/react-core/src/index.ts
+++ b/packages/react-core/src/index.ts
@@ -4,4 +4,5 @@ export * from './scalprum-component';
 export * from './scalprum-provider';
 export * from './use-scalprum';
 export * from './scalprum-context';
+export * from './use-module';
 export { ScalprumProvider as default } from './scalprum-provider';

--- a/packages/react-core/src/scalprum-component.tsx
+++ b/packages/react-core/src/scalprum-component.tsx
@@ -105,14 +105,14 @@ class BaseScalprumComponent extends React.Component<ScalprumComponentProps, Base
     console.error('Scalprum encountered an error!', error);
     console.log('Error info: ', JSON.stringify(errorInfo, null, 2));
     console.log('Component stack: ', errorInfo.componentStack);
-    this.setState({ error, errorInfo })
+    this.setState({ error, errorInfo });
   }
 
   render(): ReactNode {
     const { ErrorComponent = <DefaultErrorComponent />, ...props } = this.props;
 
     if (this.state.hasError) {
-      return React.cloneElement(ErrorComponent as React.FunctionComponentElement<BaseScalprumComponentState>, {...this.state})
+      return React.cloneElement(ErrorComponent as React.FunctionComponentElement<BaseScalprumComponentState>, { ...this.state });
     }
 
     return <LoadModule {...props} ErrorComponent={() => <Fragment>{ErrorComponent}</Fragment>} />;

--- a/packages/react-core/src/scalprum-provider.tsx
+++ b/packages/react-core/src/scalprum-provider.tsx
@@ -21,7 +21,7 @@ export function ScalprumProvider<T = Record<string, unknown>>({
   children,
   api,
 }: ScalprumProviderProps): React.ReactElement | React.ReactElement {
-  const mounted = useRef(false)
+  const mounted = useRef(false);
   const [state, setState] = useState<ScalprumState<T>>({
     initialized: false,
     config: {},
@@ -44,13 +44,13 @@ export function ScalprumProvider<T = Record<string, unknown>>({
   }, [config]);
 
   useEffect(() => {
-    if(mounted.current) {
-      setState(prev => ({
+    if (mounted.current) {
+      setState((prev) => ({
         ...prev,
-        api: api as T
-      }))
+        api: api as T,
+      }));
     }
-  }, [api])
+  }, [api]);
 
   return <ScalprumContext.Provider value={state as ScalprumState<Record<string, unknown>>}>{children}</ScalprumContext.Provider>;
 }

--- a/packages/react-core/src/use-module.ts
+++ b/packages/react-core/src/use-module.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState, useCallback } from 'react';
+import { asyncLoader, IModule } from '@scalprum/core';
+
+export function useModule(scope: string, module: string, defaultState: any): IModule | undefined {
+  const [data, setData] = useState<IModule>(defaultState);
+  const fetchModule = useCallback(async () => {
+    const Module: IModule = await asyncLoader(scope, module);
+    setData(() => Module);
+  }, [scope, module]);
+
+  useEffect(() => {
+    fetchModule();
+  }, [fetchModule]);
+
+  return data;
+}


### PR DESCRIPTION
### Async loader for generic files

Currently we support loading of React components, however if someone wants to load raw functions they are out of luck. This PR fixes such issue, by moving load function to core package and using that function in react-core.

I've also added checks for emptyness of app and module. If module doesn't start with `./` it indicates an error, but we don't want to break the UI so just warn the developer.

##### Usage:
```JS
import { asyncLoader } from '@scalprum/core';
(async () => )(
  const data = await asyncLoader('someApp', './someModule');
  console.log(data); // default and other parts of module
)
```

And with hook
```JS
import { React } from 'react';
import { useModule } from '@scalprum/react-core';

const Cmp = () => {
  const data = useModule('someApp', './someModule');
  return data ? <div>{data.default}</div>: 'loading';
}