### PR TITLE
Fix caching only one factory module.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18936,15 +18936,15 @@
     },
     "packages/core": {
       "name": "@scalprum/core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0"
     },
     "packages/react-core": {
       "name": "@scalprum/react-core",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@scalprum/core": "^0.1.0",
+        "@scalprum/core": "^0.1.1",
         "lodash": "^4.17.0"
       },
       "devDependencies": {
@@ -22490,7 +22490,7 @@
     "@scalprum/react-core": {
       "version": "file:packages/react-core",
       "requires": {
-        "@scalprum/core": "^0.1.0",
+        "@scalprum/core": "^0.1.1",
         "@types/history": "^4.7.9",
         "@types/react": "^17.0.31",
         "@types/react-dom": "^17.0.10",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalprum/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Includes core functions for scalprum scaffolding.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { initialize, GLOBAL_NAMESPACE, getScalprum, asyncLoader, getFactory } from '.';
+import { initialize, GLOBAL_NAMESPACE, getScalprum, asyncLoader, getCachedModule } from '.';
 
 describe('scalprum', () => {
   const mockInititliazeConfig = {
@@ -69,7 +69,9 @@ describe('scalprum', () => {
     const expectFactories = {
       testScope: {
         init: expect.any(Function),
-        get: expect.any(Function),
+        modules: {
+          './testModule': expect.any(Function),
+        },
         expiration: expect.any(Date),
       },
     };
@@ -83,14 +85,14 @@ describe('scalprum', () => {
     // @ts-ignore
     global.testScope = {
       init: jest.fn(),
-      get: jest.fn().mockReturnValue(jest.fn()),
+      get: jest.fn().mockReturnValue(jest.fn().mockReturnValue(jest.fn())),
     };
     await asyncLoader('testScope', './testModule');
     // @ts-ignore
     expect(global[GLOBAL_NAMESPACE].factories).toEqual(expectFactories);
   });
 
-  test('getFactory should invalidate cache after 120s', async () => {
+  test('getCachedModule should invalidate cache after 120s', async () => {
     jest.useFakeTimers();
     initialize(mockInititliazeConfig);
     // @ts-ignore
@@ -102,19 +104,19 @@ describe('scalprum', () => {
     // @ts-ignore
     global.testScope = {
       init: jest.fn(),
-      get: jest.fn().mockReturnValue(jest.fn()),
+      get: jest.fn().mockReturnValue(jest.fn().mockReturnValue(jest.fn())),
     };
     await asyncLoader('testScope', './testModule');
     // @ts-ignore
-    expect(getFactory('testScope')).toEqual(expect.any(Object));
+    expect(getCachedModule('testScope', './testModule')).toEqual(expect.any(Function));
     /**
      * Advance time by 120s + 1ms
      */
     jest.advanceTimersByTime(120 * 1000 + 1);
-    expect(getFactory('testScope')).toEqual(undefined);
+    expect(getCachedModule('testScope', './testModule')).toEqual(undefined);
   });
 
-  test('getFactory should skip factory cache', async () => {
+  test('getCachedModule should skip factory cache', async () => {
     jest.useFakeTimers();
     initialize(mockInititliazeConfig);
     // @ts-ignore
@@ -130,10 +132,10 @@ describe('scalprum', () => {
     };
     await asyncLoader('testScope', './testModule');
     // @ts-ignore
-    expect(getFactory('testScope', true)).toEqual(undefined);
+    expect(getCachedModule('testScope', './testModule', true)).toEqual(undefined);
   });
 
-  test('getFactory should invalidate cache after 300s', async () => {
+  test('getCachedModule should invalidate cache after 300s', async () => {
     jest.useFakeTimers();
     initialize({
       ...mockInititliazeConfig,
@@ -150,20 +152,20 @@ describe('scalprum', () => {
     // @ts-ignore
     global.testScope = {
       init: jest.fn(),
-      get: jest.fn().mockReturnValue(jest.fn()),
+      get: jest.fn().mockReturnValue(jest.fn().mockReturnValue(jest.fn())),
     };
     await asyncLoader('testScope', './testModule');
     // @ts-ignore
-    expect(getFactory('testScope')).toEqual(expect.any(Object));
+    expect(getCachedModule('testScope', './testModule')).toEqual(expect.any(Function));
     /**
      * Advance time by 120s + 1ms
      */
     jest.advanceTimersByTime(120 * 1000 + 1);
-    expect(getFactory('testScope')).toEqual(expect.any(Object));
+    expect(getCachedModule('testScope', './testModule')).toEqual(expect.any(Function));
     /**
      * Advance time by 180s + 1ms
      */
     jest.advanceTimersByTime(180 * 1000 + 1);
-    expect(getFactory('testScope')).toEqual(undefined);
+    expect(getCachedModule('testScope', './testModule')).toEqual(undefined);
   });
 });

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalprum/react-core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "React binding for @scalprum/core package.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -26,7 +26,7 @@
     "@types/react-router-dom": "^5.3.1"
   },
   "dependencies": {
-    "@scalprum/core": "^0.1.0",
+    "@scalprum/core": "^0.1.1",
     "lodash": "^4.17.0"
   },
   "peerDependencies": {

--- a/packages/react-core/src/use-module.ts
+++ b/packages/react-core/src/use-module.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { asyncLoader, getFactory, IModule } from '@scalprum/core';
+import { asyncLoader, getCachedModule, IModule } from '@scalprum/core';
 
 export function useModule(
   scope: string,
@@ -15,9 +15,9 @@ export function useModule(
   };
   const [data, setData] = useState<IModule>(defaultState);
   const fetchModule = useCallback(async () => {
-    const factory = getFactory(scope, defaultOptions.skipCache);
+    const cachedModule = getCachedModule(scope, module, defaultOptions.skipCache);
     let Module: IModule;
-    if (!factory) {
+    if (!cachedModule) {
       try {
         Module = await asyncLoader(scope, module);
       } catch {
@@ -26,7 +26,7 @@ export function useModule(
         );
       }
     } else {
-      Module = factory.get(module);
+      Module = cachedModule;
     }
     setData(() => Module);
   }, [scope, module]);


### PR DESCRIPTION
Previously, only the first loaded module from a factory was cached. Which caused retrieved modules to be incorrect! Now instead of cashing the factory function, we will cache the actual modules returned by the `factory.get` function. All modules share the expiration interval.