### PR TITLE
Add use load module to add modules to DOM as well

### DIFF
--- a/packages/react-core/README.md
+++ b/packages/react-core/README.md
@@ -1,0 +1,78 @@
+# @scalprum/react-core
+
+This library works with [Webpack's federated modules](https://webpack.js.org/concepts/module-federation/). Its core library for loading JS files is [@scalprum/core](https://www.npmjs.com/package/@scalprum/core) for injecting JS files (either over direct JS entrypoint or with manifest in mind) and further providing bindings to React. These bindings include loading of components and specific hooks for hot injecting modules into your application.
+
+### `ScalprumComponent`
+### `scalprumContext`
+### `useScalprum`
+### `useModule`
+
+This React hook will allow you to include any partial of a module. Meaning if your module is exporting some constants as named exports you can pick them.
+
+**!Important: the container has to be loaded in the DOM before using this hook. For this you can use `useLoadModule`, `ScalprumComponent` or directly injecting it on your own.!**
+
+Example:
+```JSX
+import React, { Suspense } from 'react';
+
+const MyCmp = () => {
+  const { default: SomeConst, someExport } = useModule('appName', './SomeModule', {}, {});
+  const calculatedValue = someExport();
+
+  return <Suspense fallback="loading">
+    <SomeConst value={calculatedValue} />
+  </Suspense>
+}
+
+export default MyCmp;
+```
+
+Module `SomeModule` from `appName` scope is exporting 2 memebers `default` (a component) and `someExport` (a function to calculate something).
+
+#### Arguments
+
+This hook accepts 4 parameters:
+* scope - container from which we'll pull the module from
+* module - name of the module we'll import
+* default state - used for fallbacks, you can for instance pass in default loader
+* options - object to fine tune the hook
+  * skipCache - flag to force reload of module even if it was loaded before
+
+### `useLoadModule`
+
+React hook to use module and load its container. This hook will allow you to load the container holding required module into DOM, if the container was loaded before it will use that one so you don't have to care about the process. If you don't know if the container was loaded and are unsure whether to use `useModule` or `useLoadModule` prefer the later, this way you won't have to deal with errors if the container was not loaded before using the module from it.
+
+```JSX
+import React, { Suspense } from 'react';
+
+const MyCmp = () => {
+  const [{ default: SomeConst, someExport }, error] = useLoadModule({
+    //appName: 'appName', // optional
+    scope: 'appName',
+    module: './SomeModule',
+    // processor: (val) => val, // optional
+  }, {}, {});
+  const calculatedValue = someExport();
+
+  return <Suspense fallback="loading">
+    <SomeConst value={calculatedValue} />
+  </Suspense>
+}
+
+export default MyCmp;
+```
+
+Module `SomeModule` from `appName` scope is exporting 2 memebers `default` (a component) and `someExport` (a function to calculate something).
+
+#### Arguments
+
+This hook accepts 3 parameters:
+* moduleDefinition - an object to describe which module from provider and the scope we want to import.
+  * appName - app container's name to load the module from (can be omited, scope will be used as fallback)
+  * scope - scope from the container to pull module from
+  * module - name of the module we'll use to import the exports from
+  * processor - function to further process the manifest (optional).\
+  Default value: `(value) => value[1].entry || value`
+* default state - used for fallbacks, you can for instance pass in default loader
+* options - object to fine tune the hook
+  * skipCache - flag to force reload of module even if it was loaded before

--- a/packages/react-core/src/index.ts
+++ b/packages/react-core/src/index.ts
@@ -3,4 +3,5 @@ export * from './scalprum-provider';
 export * from './use-scalprum';
 export * from './scalprum-context';
 export * from './use-module';
+export * from './use-load-module';
 export { ScalprumProvider as default } from './scalprum-provider';

--- a/packages/react-core/src/use-load-module.ts
+++ b/packages/react-core/src/use-load-module.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState, useRef } from 'react';
+import { asyncLoader, getCachedModule, IModule, getAppData, injectScript, processManifest } from '@scalprum/core';
+
+export type ModuleDefinition = {
+  appName?: string;
+  scope: string;
+  module: string;
+  processor?: (item: any) => string;
+};
+
+export function useLoadModule(
+  { appName, scope, module, processor }: ModuleDefinition,
+  defaultState: any,
+  options: {
+    skipCache?: boolean;
+  } = {}
+): [IModule | undefined, Error | undefined] {
+  const defaultOptions = {
+    skipCache: false,
+    ...options,
+  };
+  const { scriptLocation, manifestLocation } = getAppData(appName || scope);
+  const [data, setData] = useState<IModule>(defaultState);
+  const [error, setError] = useState<Error>();
+  const cachedModule = getCachedModule(scope, module, defaultOptions.skipCache);
+  const isMounted = useRef(true);
+  useEffect(() => {
+    if (isMounted.current) {
+      if (!cachedModule) {
+        if (scriptLocation) {
+          injectScript(appName || scope, scriptLocation)
+            .then(async () => {
+              const Module: IModule = await asyncLoader(scope, module);
+              setData(() => Module);
+            })
+            .catch((e) => {
+              setError(() => e);
+            });
+        } else if (manifestLocation) {
+          processManifest(manifestLocation, appName || scope, scope, processor)
+            .then(async () => {
+              const Module: IModule = await asyncLoader(scope, module);
+              setData(() => Module);
+            })
+            .catch((e) => {
+              setError(() => e);
+            });
+        }
+      } else {
+        try {
+          asyncLoader(scope, module).then((Module: IModule) => {
+            setData(() => Module);
+          });
+        } catch (e) {
+          setError(() => e as Error);
+        }
+      }
+    }
+
+    return () => {
+      isMounted.current = false;
+    };
+  }, [appName, scope, cachedModule, defaultOptions.skipCache]);
+
+  return [data, error];
+}

--- a/packages/react-core/src/use-module.ts
+++ b/packages/react-core/src/use-module.ts
@@ -1,5 +1,15 @@
-import { useEffect, useState, useCallback } from 'react';
-import { asyncLoader, getCachedModule, IModule } from '@scalprum/core';
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { asyncLoader, getCachedModule, IModule, getAppData, injectScript, processManifest } from '@scalprum/core';
+
+export type ModuleDefinition = {
+  appName?: string;
+  scope: string;
+  module: string;
+  processor?: (item: any) => string;
+};
+export interface IUseLoadModule {
+  moduleDef: ModuleDefinition;
+}
 
 export function useModule(
   scope: string,
@@ -36,4 +46,61 @@ export function useModule(
   }, [scope, module]);
 
   return data;
+}
+
+export function useLoadModule(
+  { appName, scope, module, processor }: ModuleDefinition,
+  defaultState: any,
+  options: {
+    skipCache?: boolean;
+  } = {}
+): [IModule | undefined, Error | undefined] {
+  const defaultOptions = {
+    skipCache: false,
+    ...options,
+  };
+  const { scriptLocation, manifestLocation } = getAppData(appName || scope);
+  const [data, setData] = useState<IModule>(defaultState);
+  const [error, setError] = useState<Error>();
+  const cachedModule = getCachedModule(scope, module, defaultOptions.skipCache);
+  const isMounted = useRef(true);
+  useEffect(() => {
+    if (isMounted.current) {
+      if (!cachedModule) {
+        if (scriptLocation) {
+          injectScript(appName || scope, scriptLocation)
+            .then(async () => {
+              const Module: IModule = await asyncLoader(scope, module);
+              setData(() => Module);
+            })
+            .catch((e) => {
+              setError(() => e);
+            });
+        } else if (manifestLocation) {
+          processManifest(manifestLocation, appName || scope, scope, processor)
+            .then(async () => {
+              const Module: IModule = await asyncLoader(scope, module);
+              setData(() => Module);
+            })
+            .catch((e) => {
+              setError(() => e);
+            });
+        }
+      } else {
+        try {
+          asyncLoader(scope, module).then((Module: IModule) => {
+            setData(() => Module);
+          });
+        } catch (e) {
+          setError(() => e as Error);
+        }
+      }
+    }
+
+    return () => {
+      isMounted.current = false;
+    };
+  }, [appName, scope, cachedModule, defaultOptions.skipCache]);
+
+  return [data, error];
 }

--- a/packages/react-core/src/use-module.ts
+++ b/packages/react-core/src/use-module.ts
@@ -1,15 +1,5 @@
-import { useEffect, useState, useCallback, useRef } from 'react';
-import { asyncLoader, getCachedModule, IModule, getAppData, injectScript, processManifest } from '@scalprum/core';
-
-export type ModuleDefinition = {
-  appName?: string;
-  scope: string;
-  module: string;
-  processor?: (item: any) => string;
-};
-export interface IUseLoadModule {
-  moduleDef: ModuleDefinition;
-}
+import { useEffect, useState, useCallback } from 'react';
+import { asyncLoader, getCachedModule, IModule } from '@scalprum/core';
 
 export function useModule(
   scope: string,
@@ -46,61 +36,4 @@ export function useModule(
   }, [scope, module]);
 
   return data;
-}
-
-export function useLoadModule(
-  { appName, scope, module, processor }: ModuleDefinition,
-  defaultState: any,
-  options: {
-    skipCache?: boolean;
-  } = {}
-): [IModule | undefined, Error | undefined] {
-  const defaultOptions = {
-    skipCache: false,
-    ...options,
-  };
-  const { scriptLocation, manifestLocation } = getAppData(appName || scope);
-  const [data, setData] = useState<IModule>(defaultState);
-  const [error, setError] = useState<Error>();
-  const cachedModule = getCachedModule(scope, module, defaultOptions.skipCache);
-  const isMounted = useRef(true);
-  useEffect(() => {
-    if (isMounted.current) {
-      if (!cachedModule) {
-        if (scriptLocation) {
-          injectScript(appName || scope, scriptLocation)
-            .then(async () => {
-              const Module: IModule = await asyncLoader(scope, module);
-              setData(() => Module);
-            })
-            .catch((e) => {
-              setError(() => e);
-            });
-        } else if (manifestLocation) {
-          processManifest(manifestLocation, appName || scope, scope, processor)
-            .then(async () => {
-              const Module: IModule = await asyncLoader(scope, module);
-              setData(() => Module);
-            })
-            .catch((e) => {
-              setError(() => e);
-            });
-        }
-      } else {
-        try {
-          asyncLoader(scope, module).then((Module: IModule) => {
-            setData(() => Module);
-          });
-        } catch (e) {
-          setError(() => e as Error);
-        }
-      }
-    }
-
-    return () => {
-      isMounted.current = false;
-    };
-  }, [appName, scope, cachedModule, defaultOptions.skipCache]);
-
-  return [data, error];
 }


### PR DESCRIPTION
### Enable use load module

The current `useModule` is good as is, if you previously loaded the container in memory. If the app didn't load the container it won't load and throw an error of missing container.

This PR fixes such issue by introducing similiar hook `useLoadModule` which is in principal similiar to what `useModule` and `ScalprumComonent` is doing. It loads the app definition, either loads the script or manifest and fetches the module.