### PR TITLE
Lock module preload during normal load

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -85,7 +85,6 @@ export const setPendingLoading = (scope: string, module: string, promise: Promis
   promise
     .then((data) => {
       delete window[GLOBAL_NAMESPACE].pendingLoading[`${scope}#${module}`];
-      console.log('Pre loading has finished!');
       return data;
     })
     .catch(() => {
@@ -107,7 +106,7 @@ export const preloadModule = async (scope: string, module: string, processor?: (
     modulePromise = processManifest(manifestLocation, scope, scope, processor).then(() => asyncLoader(scope, module));
   }
   // add preloading information to registry
-  return setPendingLoading('preLoad', './PreLoadedModule', Promise.resolve(modulePromise));
+  return setPendingLoading(scope, module, Promise.resolve(modulePromise));
 };
 
 export const initialize = <T = unknown>({

--- a/packages/react-core/src/scalprum-component.tsx
+++ b/packages/react-core/src/scalprum-component.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useEffect, Suspense, useState, ReactNode, useReducer } from 'react';
-import { getCachedModule, getAppData, injectScript, processManifest, getPendingLoading } from '@scalprum/core';
+import { getCachedModule, getAppData, injectScript, processManifest, getPendingLoading, setPendingLoading } from '@scalprum/core';
 import isEqual from 'lodash/isEqual';
 import { loadComponent } from './async-loader';
 
@@ -50,21 +50,25 @@ const LoadModule: React.ComponentType<ScalprumComponentProps & { ErrorComponent:
        */
       if (!cachedModule) {
         if (scriptLocation) {
-          injectScript(appName, scriptLocation)
+          const injecttionPromise = injectScript(appName, scriptLocation)
             .then(() => {
               isMounted && setComponent(() => React.lazy(loadComponent(scope, module, ErrorComponent)));
             })
             .catch(() => {
               isMounted && setComponent(() => ErrorComponent);
             });
+          // lock module preload
+          setPendingLoading(scope, module, injecttionPromise);
         } else if (manifestLocation) {
-          processManifest(manifestLocation, appName, scope, processor)
+          const processPromise = processManifest(manifestLocation, appName, scope, processor)
             .then(() => {
               isMounted && setComponent(() => React.lazy(loadComponent(scope, module, ErrorComponent)));
             })
             .catch(() => {
               isMounted && setComponent(() => ErrorComponent);
             });
+          // lock module preload
+          setPendingLoading(scope, module, processPromise);
         }
       } else {
         try {


### PR DESCRIPTION
There is an edge case that can cause module loading to be duplicated if you start module preloading during the normal loading phase that has yet to be finished.

### Changes
- use actual module and scope values to index preloading locks
- lock module preloading during the standard module loading process