### PR TITLE
Better error handling

### DIFF
--- a/cypress/e2e/test-app/module-loading-errors.cy.js
+++ b/cypress/e2e/test-app/module-loading-errors.cy.js
@@ -1,0 +1,62 @@
+describe('Module error loading handling', () => {
+  it('should show cunk loading error message', () => {
+    cy.visit('http://localhost:8123');
+
+    // intercept webpack chunk and return 500 response
+    cy.intercept('GET', '/src_modules_preLoad_tsx.js', {
+      statusCode: 500,
+    });
+
+    cy.on('uncaught:exception', () => {
+      // exceptions are expected during this test
+      // returning false here prevents Cypress from failing the test
+      return false;
+    });
+
+    const button = cy.get('#render-preload-module');
+    button.click();
+
+    cy.get('p').contains('Loading chunk src_modules_preLoad_tsx failed.').should('exist');
+  });
+
+  it('should try self healing and render on second try', () => {
+    let c = 0;
+    cy.visit('http://localhost:8123');
+
+    // intercept webpack chunk and return 500 response
+    cy.intercept('GET', '/src_modules_preLoad_tsx.js', (res) => {
+      c += 1;
+      if (c === 1) {
+        // make sure the 500 request was sent
+        expect(c).equal(1);
+        return res.reply({
+          statusCode: 500,
+        });
+      }
+
+      res.continue();
+    }).as('chunk');
+
+    cy.on('uncaught:exception', () => {
+      // exceptions are expected during this test
+      // returning false here prevents Cypress from failing the test
+      return false;
+    });
+
+    const button = cy.get('#render-preload-module');
+    button.click();
+
+    cy.wait('@chunk');
+
+    cy.get('h2#preload-heading').contains('This module is supposed to be pre-loaded').should('exist');
+  });
+
+  it('should handle runtime module error', () => {
+    cy.visit('http://localhost:8123/runtime-error');
+
+    // the react app is still active
+    cy.get('h2').contains('Runtime error route').should('exist');
+    // error component is rendered
+    cy.get('p').contains('Synthetic error message').should('exist');
+  });
+});

--- a/packages/react-core/src/async-loader.tsx
+++ b/packages/react-core/src/async-loader.tsx
@@ -8,7 +8,6 @@ export function loadComponent(scope: string, module: string, ErrorComponent: Rea
     try {
       Module = await asyncLoader(scope, module);
     } catch (e: any) {
-      console.error(e, ErrorComponent);
       Module = {
         default: (props: Record<string, any>) => <ErrorComponent {...props} error={e} />,
       };

--- a/packages/react-core/src/async-loader.tsx
+++ b/packages/react-core/src/async-loader.tsx
@@ -1,19 +1,16 @@
 import React from 'react';
 import { asyncLoader } from '@scalprum/core';
-
-const DefaultErrorComponent: React.ComponentType<any> = () => {
-  return <span>Error while loading component!</span>;
-};
+import DefaultErrorComponent from './default-error-component';
 
 export function loadComponent(scope: string, module: string, ErrorComponent: React.ComponentType<any> = DefaultErrorComponent) {
   return async (): Promise<{ default: React.ComponentType<any> }> => {
     let Module;
     try {
       Module = await asyncLoader(scope, module);
-    } catch (e) {
-      console.error(e);
+    } catch (e: any) {
+      console.error(e, ErrorComponent);
       Module = {
-        default: ErrorComponent,
+        default: (props: Record<string, any>) => <ErrorComponent {...props} error={e} />,
       };
     }
 

--- a/packages/react-core/src/default-error-component.tsx
+++ b/packages/react-core/src/default-error-component.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const DefaultErrorComponent = ({ error, errorInfo }: { error?: any; errorInfo?: any }) => {
+  return (
+    <div>
+      <h2>Error loading component</h2>
+      {error?.message && <p>{error.message}</p>}
+      {errorInfo?.componentStack ? <pre>{errorInfo?.componentStack}</pre> : error?.stack && <pre>{error.stack}</pre>}
+    </div>
+  );
+};
+
+export default DefaultErrorComponent;

--- a/packages/react-core/src/scalprum-component.tsx
+++ b/packages/react-core/src/scalprum-component.tsx
@@ -39,12 +39,7 @@ const LoadModule: React.ComponentType<LoadModuleProps> = ({
   const cachedModule = getCachedModule(scope, module, skipCache);
   useEffect(() => {
     let isMounted = true;
-    const handleLoadingError = () =>
-      isMounted &&
-      setComponent(() => (props: any) => {
-        console.log('Anonumous component', props);
-        return <ErrorComponent {...props} />;
-      });
+    const handleLoadingError = () => isMounted && setComponent(() => (props: any) => <ErrorComponent {...props} />);
     /**
      * Check if module is being pre-loaded
      */

--- a/packages/test-app/src/components/LoadingComponent.tsx
+++ b/packages/test-app/src/components/LoadingComponent.tsx
@@ -1,0 +1,10 @@
+import React, { useEffect } from 'react';
+
+const LoadingComponent: React.FC = () => {
+  useEffect(() => {
+    console.log('Loading component mounted');
+  }, []);
+  return <div>Super duper loading</div>;
+};
+
+export default LoadingComponent;

--- a/packages/test-app/src/entry.tsx
+++ b/packages/test-app/src/entry.tsx
@@ -1,6 +1,9 @@
-import React, { Fragment, useEffect, useState } from 'react';
+import React, { Fragment, useState } from 'react';
 import { ScalprumComponent, ScalprumProvider, useScalprum } from '@scalprum/react-core';
 import { preloadModule } from '@scalprum/core';
+import { BrowserRouter, Switch, Route } from 'react-router-dom';
+import LoadingComponent from './components/LoadingComponent';
+import RuntimeErrorRoute from './routes/RuntimeErrorRoute';
 
 const Initializer: React.ComponentType = ({ children }) => {
   const { initialized } = useScalprum();
@@ -9,23 +12,6 @@ const Initializer: React.ComponentType = ({ children }) => {
   }
 
   return <Fragment>{children}</Fragment>;
-};
-
-// const preLoadModule = async (scope: string, module: string, processor?: (item: any) => string, skipCache = false) => {
-//   const { manifestLocation } = getAppData(scope);
-//   const cachedModule = getCachedModule(scope, module, skipCache);
-//   let modulePromise = getPendingLoading(scope, module);
-//   if (!modulePromise && !cachedModule && manifestLocation) {
-//     modulePromise = processManifest(manifestLocation, scope, scope, processor).then(() => asyncLoader(scope, module));
-//   }
-//   return setPendingLoading('preLoad', './PreLoadedModule', Promise.resolve(modulePromise));
-// };
-
-const LoadingComponent: React.FC = () => {
-  useEffect(() => {
-    console.log('Loading component mounted');
-  }, []);
-  return <div>Super duper loading</div>;
 };
 
 const ContentStuff = () => {
@@ -40,8 +26,8 @@ const ContentStuff = () => {
   return (
     <>
       <div>
-        <button onMouseEnter={handlePreload} onClick={() => setShowPreLoadedModule((prev) => !prev)}>
-          Hower over this to pre-load; Click to show
+        <button id="render-preload-module" onMouseEnter={handlePreload} onClick={() => setShowPreLoadedModule((prev) => !prev)}>
+          Hover over this to pre-load; Click to show
         </button>
       </div>
       <ScalprumComponent LoadingComponent={LoadingComponent} appName="testApp" scope="testApp" module="./ModuleOne" />
@@ -68,9 +54,18 @@ const Entry = () => {
         },
       }}
     >
-      <Initializer>
-        <ContentStuff />
-      </Initializer>
+      <BrowserRouter>
+        <Initializer>
+          <Switch>
+            <Route path="/runtime-error">
+              <RuntimeErrorRoute />
+            </Route>
+            <Route path="/">
+              <ContentStuff />
+            </Route>
+          </Switch>
+        </Initializer>
+      </BrowserRouter>
     </ScalprumProvider>
   );
 };

--- a/packages/test-app/src/modules/errorModule.tsx
+++ b/packages/test-app/src/modules/errorModule.tsx
@@ -1,0 +1,5 @@
+const ErrorModule = () => {
+  throw new Error('Synthetic error message');
+};
+
+export default ErrorModule;

--- a/packages/test-app/src/modules/preLoad.tsx
+++ b/packages/test-app/src/modules/preLoad.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 const PreLoad = () => {
   return (
     <div>
-      <h2>This module is supposed to be pre-loaded</h2>
+      <h2 id="preload-heading">This module is supposed to be pre-loaded</h2>
     </div>
   );
 };

--- a/packages/test-app/src/routes/RuntimeErrorRoute.tsx
+++ b/packages/test-app/src/routes/RuntimeErrorRoute.tsx
@@ -1,0 +1,14 @@
+import { ScalprumComponent } from '@scalprum/react-core';
+import React from 'react';
+import LoadingComponent from '../components/LoadingComponent';
+
+const RuntimeErrorRoute = () => {
+  return (
+    <div>
+      <h2>Runtime error route</h2>
+      <ScalprumComponent LoadingComponent={LoadingComponent} appName="testApp" scope="testApp" module="./ErrorModule" />
+    </div>
+  );
+};
+
+export default RuntimeErrorRoute;

--- a/packages/test-app/webpack.config.js
+++ b/packages/test-app/webpack.config.js
@@ -17,6 +17,7 @@ const TestAppFederation = new ModuleFederationPlugin({
   exposes: {
     './ModuleOne': path.resolve(__dirname, './src/modules/moduleOne.tsx'),
     './ModuleTwo': path.resolve(__dirname, './src/modules/moduleTwo.tsx'),
+    './ErrorModule': path.resolve(__dirname, './src/modules/errorModule.tsx'),
   },
   shared: [
     {
@@ -124,6 +125,7 @@ module.exports = {
   },
   optimization: {
     minimizer: [new TerserPlugin()],
+    chunkIds: 'named',
   },
   devServer: {
     historyApiFallback: true,


### PR DESCRIPTION
part of: https://issues.redhat.com/browse/RHCLOUD-21185

### Changes
- always pass the error message to the `ErrorComponent` (sometimes the error and stack were not included)
- add e2e test for error component rendering
- add e2e test for self healing attempt
- add e2e test for webpack chunk loading error