### PR TITLE
fix(react-core): Do not check cache during render.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19602,7 +19602,7 @@
     },
     "packages/react-core": {
       "name": "@scalprum/react-core",
-      "version": "0.2.4",
+      "version": "0.2.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@scalprum/core": "^0.2.3",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalprum/react-core",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "React binding for @scalprum/core package.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react-core/src/scalprum-component.tsx
+++ b/packages/react-core/src/scalprum-component.tsx
@@ -36,8 +36,8 @@ const LoadModule: React.ComponentType<LoadModuleProps> = ({
   const { scriptLocation, manifestLocation } = getAppData(appName);
   const [reRender, forceRender] = useReducer((prev) => prev + 1, 0);
   const [Component, setComponent] = useState<React.ComponentType<{ ref?: React.Ref<unknown> }> | undefined>(undefined);
-  const cachedModule = getCachedModule(scope, module, skipCache);
   useEffect(() => {
+    const cachedModule = getCachedModule(scope, module, skipCache);
     let isMounted = true;
     const handleLoadingError = () => isMounted && setComponent(() => (props: any) => <ErrorComponent {...props} />);
     /**
@@ -83,7 +83,7 @@ const LoadModule: React.ComponentType<LoadModuleProps> = ({
     return () => {
       isMounted = false;
     };
-  }, [appName, scope, cachedModule, skipCache, reRender]);
+  }, [appName, scope, skipCache, reRender]);
 
   return <Suspense fallback={fallback}>{Component ? <Component ref={innerRef} {...props} /> : fallback}</Suspense>;
 };


### PR DESCRIPTION
Checking cache in render can cause race-condition if many rendering cycles are triggered during module re-initialization. Causing context issues.  