### PR TITLE
Prevent duplicate script injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# cypress videos
+/**/*.mp4

--- a/package-lock.json
+++ b/package-lock.json
@@ -19597,15 +19597,15 @@
     },
     "packages/core": {
       "name": "@scalprum/core",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0"
     },
     "packages/react-core": {
       "name": "@scalprum/react-core",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@scalprum/core": "^0.2.3",
+        "@scalprum/core": "^0.2.4",
         "lodash": "^4.17.0"
       },
       "devDependencies": {
@@ -23204,7 +23204,7 @@
     "@scalprum/react-core": {
       "version": "file:packages/react-core",
       "requires": {
-        "@scalprum/core": "^0.2.3",
+        "@scalprum/core": "^0.2.4",
         "@types/history": "^4.7.9",
         "@types/react": "^17.0.31",
         "@types/react-dom": "^17.0.10",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalprum/core",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Includes core functions for scalprum scaffolding.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -134,13 +134,18 @@ export const initialize = <T = unknown>({
 
 export const getAppData = (name: string): AppMetadata => window[GLOBAL_NAMESPACE].appsConfig[name];
 
+const shouldInjectScript = (src: string) => document.querySelectorAll(`script[src="${src}"]`)?.length === 0;
+
 export const injectScript = (
   appName: string,
   scriptLocation: string,
   skipPending: boolean | undefined = false
-): Promise<[unknown, HTMLScriptElement | undefined]> => {
+): Promise<[any, HTMLScriptElement | undefined]> => {
   let s: HTMLScriptElement | undefined = undefined;
-  const injectionPromise: Promise<[unknown, HTMLScriptElement | undefined]> = new Promise((res, rej) => {
+  if (!shouldInjectScript(scriptLocation)) {
+    return Promise.resolve([appName, document.querySelectorAll(`script[src="${scriptLocation}"]`)?.[0] as HTMLScriptElement]);
+  }
+  const injectionPromise: Promise<[any, HTMLScriptElement | undefined]> = new Promise((res, rej) => {
     s = document.createElement('script');
     s.src = scriptLocation;
     s.id = appName;

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalprum/react-core",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "React binding for @scalprum/core package.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -26,7 +26,7 @@
     "@types/react-router-dom": "^5.3.1"
   },
   "dependencies": {
-    "@scalprum/core": "^0.2.3",
+    "@scalprum/core": "^0.2.4",
     "lodash": "^4.17.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Injecting runtime chunk multiple times can cause root re-mount.