### PR TITLE
Block duplicate manifest processing.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19597,15 +19597,15 @@
     },
     "packages/core": {
       "name": "@scalprum/core",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "Apache-2.0"
     },
     "packages/react-core": {
       "name": "@scalprum/react-core",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "license": "Apache-2.0",
       "dependencies": {
-        "@scalprum/core": "^0.2.4",
+        "@scalprum/core": "^0.2.6",
         "lodash": "^4.17.0"
       },
       "devDependencies": {
@@ -23204,7 +23204,7 @@
     "@scalprum/react-core": {
       "version": "file:packages/react-core",
       "requires": {
-        "@scalprum/core": "^0.2.4",
+        "@scalprum/core": "^0.2.6",
         "@types/history": "^4.7.9",
         "@types/react": "^17.0.31",
         "@types/react-dom": "^17.0.10",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalprum/core",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Includes core functions for scalprum scaffolding.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalprum/react-core",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "React binding for @scalprum/core package.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -26,7 +26,7 @@
     "@types/react-router-dom": "^5.3.1"
   },
   "dependencies": {
-    "@scalprum/core": "^0.2.4",
+    "@scalprum/core": "^0.2.6",
     "lodash": "^4.17.0"
   },
   "peerDependencies": {

--- a/packages/react-core/src/scalprum-component.test.tsx
+++ b/packages/react-core/src/scalprum-component.test.tsx
@@ -46,7 +46,7 @@ describe('<ScalprumComponent />', () => {
 
   test('should retrieve script location', () => {
     ScalprumCore.initialize({ appsConfig: mockInitScalprumConfig });
-    ScalprumCore.setPendingInjection('appOne', jest.fn());
+    ScalprumCore.setPendingInjection('appOne', Promise.resolve());
     render(<ScalprumComponent appName="appOne" scope="some" module="test" />);
 
     expect(getAppDataSpy).toHaveBeenCalledWith('appOne');
@@ -55,7 +55,7 @@ describe('<ScalprumComponent />', () => {
   test('should retrieve manifest location', () => {
     getAppDataSpy.mockReturnValueOnce(mockInitScalpumConfigManifest.appOne);
     ScalprumCore.initialize({ appsConfig: mockInitScalpumConfigManifest });
-    ScalprumCore.setPendingInjection('appOne', jest.fn());
+    ScalprumCore.setPendingInjection('appOne', Promise.resolve());
     render(<ScalprumComponent appName="appOne" scope="some" module="test" />);
 
     expect(getAppDataSpy).toHaveBeenCalledWith('appOne');
@@ -64,7 +64,7 @@ describe('<ScalprumComponent />', () => {
   test('should inject script and mount app if it was not initialized before', async () => {
     ScalprumCore.initialize({ appsConfig: mockInitScalprumConfig });
     injectScriptSpy.mockImplementationOnce(() => {
-      ScalprumCore.setPendingInjection('appOne', jest.fn());
+      ScalprumCore.setPendingInjection('appOne', Promise.resolve());
       return Promise.resolve(['', undefined]);
     });
     await act(async () => {
@@ -77,7 +77,7 @@ describe('<ScalprumComponent />', () => {
     getAppDataSpy.mockReturnValueOnce(mockInitScalpumConfigManifest.appOne);
     ScalprumCore.initialize({ appsConfig: mockInitScalpumConfigManifest });
     processManifestSpy.mockImplementationOnce(() => {
-      ScalprumCore.setPendingInjection('appOne', jest.fn());
+      ScalprumCore.setPendingInjection('appOne', Promise.resolve());
       return Promise.resolve([['', undefined]]);
     });
     await act(async () => {
@@ -90,7 +90,7 @@ describe('<ScalprumComponent />', () => {
   test('should render test component', async () => {
     ScalprumCore.initialize({ appsConfig: mockInitScalprumConfig });
     injectScriptSpy.mockImplementationOnce(() => {
-      ScalprumCore.setPendingInjection('appOne', jest.fn());
+      ScalprumCore.setPendingInjection('appOne', Promise.resolve());
       return Promise.resolve(['', undefined]);
     });
     let container;
@@ -118,7 +118,7 @@ describe('<ScalprumComponent />', () => {
     getAppDataSpy.mockReturnValueOnce(mockInitScalpumConfigManifest.appOne);
     ScalprumCore.initialize({ appsConfig: mockInitScalprumConfig });
     processManifestSpy.mockImplementationOnce(() => {
-      ScalprumCore.setPendingInjection('appOne', jest.fn());
+      ScalprumCore.setPendingInjection('appOne', Promise.resolve());
       return Promise.resolve([['', undefined]]);
     });
     let container;
@@ -148,7 +148,7 @@ describe('<ScalprumComponent />', () => {
       .mockReturnValueOnce(() => new Promise((res) => setTimeout(() => res(import('./TestComponent')), 500)));
     ScalprumCore.initialize({ appsConfig: mockInitScalprumConfig });
     injectScriptSpy.mockImplementationOnce(() => {
-      ScalprumCore.setPendingInjection('appOne', jest.fn());
+      ScalprumCore.setPendingInjection('appOne', Promise.resolve());
       return Promise.resolve(['', undefined]);
     });
 
@@ -181,7 +181,7 @@ describe('<ScalprumComponent />', () => {
     );
     ScalprumCore.initialize({ appsConfig: mockInitScalprumConfig });
     injectScriptSpy.mockImplementationOnce(() => {
-      ScalprumCore.setPendingInjection('appOne', jest.fn());
+      ScalprumCore.setPendingInjection('appOne', Promise.resolve());
       return Promise.reject(['', undefined]);
     });
 
@@ -234,7 +234,7 @@ describe('<ScalprumComponent />', () => {
   test('should skip scalprum cache', async () => {
     jest.useFakeTimers();
     injectScriptSpy.mockImplementationOnce(() => {
-      ScalprumCore.setPendingInjection('appOne', jest.fn());
+      ScalprumCore.setPendingInjection('appOne', Promise.resolve());
       return Promise.resolve(['', undefined]);
     });
     const cachedModule = {
@@ -281,7 +281,7 @@ describe('<ScalprumComponent />', () => {
       .mockReturnValueOnce(() => import('./TestComponent'));
     ScalprumCore.initialize({ appsConfig: mockInitScalprumConfig });
     injectScriptSpy.mockImplementationOnce(() => {
-      ScalprumCore.setPendingInjection('appOne', jest.fn());
+      ScalprumCore.setPendingInjection('appOne', Promise.resolve());
       return Promise.resolve(['', undefined]);
     });
 
@@ -313,7 +313,7 @@ describe('<ScalprumComponent />', () => {
     );
     ScalprumCore.initialize({ appsConfig: mockInitScalprumConfig });
     injectScriptSpy.mockImplementation(() => {
-      ScalprumCore.setPendingInjection('appOne', jest.fn());
+      ScalprumCore.setPendingInjection('appOne', Promise.resolve());
       return Promise.reject(['', undefined]);
     });
     let container;


### PR DESCRIPTION
When more than one manifests at the same time are processed, it can lead to a race condition where the remote container might not be ready in the DOM, and it cannot be initialized for sharing.

Added a lock, that will only ever allow processing one manifest at a time.