### PR TITLE
fix(types): allow arbitrary props in ScalprumComponent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,18 @@ jobs:
         with:
           fetch-depth: 0
       - uses: './.github/actions/test-component'
+  typecheck:
+    runs-on: ubuntu-latest
+    needs: [install]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: './.github/actions/node-cache'
+      - name: Install deps
+        run: npm ci
+      - name: Typecheck all packages
+        run: npm run typecheck
   build:
     runs-on: ubuntu-latest
     needs: [install]
@@ -86,7 +98,7 @@ jobs:
       - uses: './.github/actions/test-e2e'
   release:
     runs-on: ubuntu-latest
-    needs: [install, lint, test, build, test-e2e, test-component]
+    needs: [install, lint, test, build, test-e2e, test-component, typecheck]
     if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4

--- a/examples/test-app/src/entry.tsx
+++ b/examples/test-app/src/entry.tsx
@@ -54,17 +54,20 @@ const Entry = () => {
       pluginSDKOptions={{
         pluginLoaderOptions: {
           transformPluginManifest(manifest) {
-            const host = config[manifest.name]?.assetsHost;
-            if (host) {
+            if ('loadScripts' in manifest) {
+              const host = config[manifest.name]?.assetsHost;
+              if (host) {
+                return {
+                  ...manifest,
+                  loadScripts: manifest.loadScripts.map((script: string) => `${host}/${script}`),
+                };
+              }
               return {
                 ...manifest,
-                loadScripts: manifest.loadScripts.map((script) => `${host}/${script}`),
+                loadScripts: manifest.loadScripts.map((script: string) => `${script}`),
               };
             }
-            return {
-              ...manifest,
-              loadScripts: manifest.loadScripts.map((script) => `${script}`),
-            };
+            return manifest;
           },
         },
       }}

--- a/nx.json
+++ b/nx.json
@@ -30,6 +30,11 @@
     "component-test": {
       "cache": true,
       "inputs": ["default", "^production"]
+    },
+    "typecheck": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": ["production", "^production"]
     }
   },
   "namedInputs": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "npm-run-all --parallel test:*",
     "build": "nx run-many -t build",
     "lint": "nx run-many -t lint",
+    "typecheck": "nx run-many -t typecheck",
     "postinstall": "rm -rf .webpack-cache"
   },
   "private": true,

--- a/packages/build-utils/project.json
+++ b/packages/build-utils/project.json
@@ -50,6 +50,9 @@
       "options": {
         "jestConfig": "packages/build-utils/jest.config.ts"
       }
+    },
+    "typecheck": {
+      "command": "tsc -p packages/build-utils/tsconfig.lib.json --noEmit"
     }
   }
 }

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -39,6 +39,9 @@
     },
     "syncDependencies": {
       "executor": "@scalprum/build-utils:sync-dependencies"
+    },
+    "typecheck": {
+      "command": "tsc -p packages/core/tsconfig.esm.json --noEmit"
     }
   }
 }

--- a/packages/react-core/project.json
+++ b/packages/react-core/project.json
@@ -44,6 +44,9 @@
         "devServerTarget": "test-app:build",
         "skipServe": true
       }
+    },
+    "typecheck": {
+      "command": "tsc -p packages/react-core/tsconfig.esm.json --noEmit"
     }
   }
 }

--- a/packages/react-core/src/scalprum-component.test.tsx
+++ b/packages/react-core/src/scalprum-component.test.tsx
@@ -231,7 +231,8 @@ describe('<ScalprumComponent />', () => {
     };
     const { container } = render(<ScalprumComponent {...props} />);
     /**
-     * Should render Loading component
+     * Should render Suspense fallback during module load.
+     * LoadingComponent is forwarded to remote component, not used by ScalprumComponent.
      */
     expect(container).toMatchSnapshot();
     await act(async () => {
@@ -370,5 +371,22 @@ describe('<ScalprumComponent />', () => {
     expect(loadComponentSpy).not.toHaveBeenCalled();
     expect(container).toMatchSnapshot();
     expect(screen.getAllByTestId('named-component')).toHaveLength(1);
+  });
+
+  test('should accept arbitrary forwarded props', async () => {
+    processManifestSpy.mockImplementationOnce(() => Promise.resolve());
+    ScalprumCore.initialize({ appsConfig: mockInitScalprumConfig });
+    await act(async () => {
+      render(
+        <ScalprumComponent
+          scope="appOne"
+          module="test"
+          history={{} as any}
+          store={{} as any}
+          appName="myApp"
+        />,
+      );
+    });
+    expect(getAppDataSpy).toHaveBeenCalledWith('appOne');
   });
 });

--- a/packages/react-core/src/scalprum-component.tsx
+++ b/packages/react-core/src/scalprum-component.tsx
@@ -15,13 +15,18 @@ import DefaultErrorComponent from './default-error-component';
 import { PrefetchProvider } from './prefetch-context';
 import { useScalprum } from './use-scalprum';
 
-export type ScalprumComponentProps<API extends Record<string, any> = {}, Props extends Record<string, any> = {}> = Props & {
+export type ScalprumComponentProps<API extends Record<string, any> = {}, Props extends Record<string, any> = Record<string, any>> = Props & {
   fallback?: NonNullable<React.ReactNode> | null;
+  /** Forwarded to remote component. Not consumed by ScalprumComponent. */
   api?: API;
   scope: string;
   module: string;
   importName?: string;
   ErrorComponent?: React.ReactElement;
+  /**
+   * Forwarded to remote component for internal loading states.
+   * Not consumed by ScalprumComponent - use `fallback` for module loading UI.
+   */
   LoadingComponent?: React.ComponentType;
   innerRef?: React.Ref<unknown>;
   processor?: (item: any) => string[];
@@ -221,6 +226,10 @@ class BaseScalprumComponent extends React.Component<ScalprumComponentProps, Base
   }
 }
 
-export const ScalprumComponent: React.ComponentType<ScalprumComponentProps> = React.forwardRef((props, ref) => (
+/**
+ * ScalprumComponent forwards all unrecognized props to the dynamically loaded remote component.
+ * Pass any additional props needed by your remote module (e.g., history, store, appName).
+ */
+export const ScalprumComponent: React.ComponentType<ScalprumComponentProps> = React.forwardRef((props: any, ref) => (
   <BaseScalprumComponent {...props} innerRef={ref} />
-));
+)) as React.ComponentType<ScalprumComponentProps>;

--- a/packages/react-core/src/scalprum-provider.tsx
+++ b/packages/react-core/src/scalprum-provider.tsx
@@ -35,8 +35,11 @@ export type ScalprumProviderProps<T extends Record<string, any> = Record<string,
   | ScalprumProviderInstanceProps<T>
   | ScalprumProviderConfigurableProps<T>;
 
-function baseTransformPluginManifest(manifest: PluginManifest): PluginManifest {
-  return { ...manifest, loadScripts: manifest.loadScripts.map((script) => `${manifest.baseURL}${script}`) };
+function baseTransformPluginManifest<T extends PluginManifest>(manifest: T): T {
+  if ('loadScripts' in manifest) {
+    return { ...manifest, loadScripts: manifest.loadScripts.map((script: string) => `${manifest.baseURL}${script}`) };
+  }
+  return manifest;
 }
 
 export function ScalprumProvider<T extends Record<string, any> = Record<string, any>>(

--- a/packages/react-test-utils/project.json
+++ b/packages/react-test-utils/project.json
@@ -35,6 +35,9 @@
     },
     "syncDependencies": {
       "executor": "@scalprum/build-utils:sync-dependencies"
+    },
+    "typecheck": {
+      "command": "tsc -p packages/react-test-utils/tsconfig.esm.json --noEmit"
     }
   }
 }


### PR DESCRIPTION
`ScalprumComponent` accepts props like `history`, `store`, `appName` at runtime (forwarded to remote components) but TypeScript interface rejected them, causing compilation errors during React 19 migration work.

Also fixed pre-existing build errors where `transformPluginManifest` functions accessed `loadScripts`/`baseURL` without handling `PluginManifest` union type (RemotePluginManifest vs LocalPluginManifest). These errors were latent on `main` — real TypeScript errors (5 in `scalprum-provider.tsx`) but not caught by CI because `nx affected` only rebuilds changed packages, and `scalprum-provider.tsx` hadn't been modified since `PluginManifest` became a union type in the SDK v5 upgrade.

To prevent latent type errors in the future, added a whole-repo typecheck job to CI that runs `tsc --noEmit` on all packages (not just affected ones).

## Changes

### ScalprumComponent Props Fix
- Changed `Props` generic default from `{}` to `Record<string, any>`
- Allows arbitrary props forwarded to remote components while preserving type safety for known props
- Added JSDoc documenting prop forwarding behavior
- Added test verifying arbitrary props compile without errors

**Files:**
- `packages/react-core/src/scalprum-component.tsx`
- `packages/react-core/src/scalprum-component.test.tsx`

### PluginManifest Union Type Fix
- Made `baseTransformPluginManifest` generic with `'loadScripts' in manifest` type guard
- Handles union correctly - transforms RemotePluginManifest, passes through LocalPluginManifest unchanged
- Applied same fix to test-app example

**Files:**
- `packages/react-core/src/scalprum-provider.tsx`
- `examples/test-app/src/entry.tsx`

### CI Typecheck Job (Prevention)
- Added `typecheck` Nx target to all packages with `dependsOn: ["^build"]` to handle cross-package type resolution
- Added `typecheck` CI job that runs `nx run-many -t typecheck` (not `nx affected`) to always check all packages
- Uses `npm ci` for deterministic installs
- Added to release job dependencies

**Files:**
- `nx.json`
- `packages/*/project.json` (all 4 packages)
- `package.json`
- `.github/workflows/ci.yml`

## Testing

All 91 tests pass. Build succeeds without TypeScript errors.

Typecheck verification:
- Current branch: `npm run typecheck` passes
- `main` branch: `tsc -p packages/react-core/tsconfig.esm.json --noEmit` shows 5 errors (confirms detection works)

### Manual integration test against frontend-components

Verified the Props fix resolves the real-world type errors in [`frontend-components`](https://github.com/RedHatInsights/frontend-components) (RHCLOUD-47402 branch).

**Setup:**
```bash
# In frontend-components, revert to published @scalprum/react-core@0.11.1 (Props = {})
npm install @scalprum/react-core@0.11.1

# Branch has 5 Inventory .js files converted to .tsx (PropTypes → TypeScript)
# These files pass history, store, appName props through ScalprumComponent
```

**Before fix** — `npx tsc -p packages/components/tsconfig.esm.json --noEmit` produces 8 errors:
```
InventoryTable.tsx:    error TS2322: Property 'history' does not exist on type '...ScalprumComponentProps...'
DetailWrapper.tsx:     error TS2322: Property 'history' does not exist on type '...ScalprumComponentProps...'
InventoryDetail.tsx:   error TS2322: Property 'history' does not exist on type '...ScalprumComponentProps...'
InventoryDetailHead.tsx: error TS2322: Property 'history' does not exist on type '...ScalprumComponentProps...'
```
Each file had two errors: `history` rejected by `ScalprumComponentProps<{}, {}>` (Props default `= {}`), plus a `children`/`className` error on wrapper component (unrelated).

**After fix** — installed local build from this PR branch (`npm pack` + `npm install <tarball>`):
```bash
cd ~/scalprum && npm run build
cd dist/packages/react-core && npm pack
cd ~/frontend-components
npm install ~/scalprum/dist/packages/react-core/scalprum-react-core-0.11.1.tgz
npx tsc -p packages/components/tsconfig.esm.json --noEmit
```

Result: all `history`/`store`/`appName` type errors resolved. Only remaining errors are unrelated `IntrinsicAttributes` issues in the wrapper component typing (separate fix).

## Context

Discovered during React 19 readiness work for `@redhat-cloud-services/frontend-components` (RHCLOUD-47402).

Related: Created RHCLOUD-47493 for broader CI improvements (.nvmrc, setup-environment action, standardize npm ci).