### PR TITLE
fix(publish): add publishConfig.access for scoped packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,9 @@
   "repository": "https://github.com/scalprum/scaffloding.git",
   "author": "Martin Marosi <marvusm.mmi@gmail.com>",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {},
   "dependencies": {
     "@openshift/dynamic-plugin-sdk": "^5.0.1",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -8,6 +8,9 @@
   "repository": "https://github.com/scalprum/scaffloding.git",
   "author": "Martin Marosi <marvusm.mmi@gmail.com>",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {},
   "devDependencies": {
     "@types/react": "^18.3.0",

--- a/packages/react-test-utils/package.json
+++ b/packages/react-test-utils/package.json
@@ -8,6 +8,9 @@
   "repository": "https://github.com/scalprum/scaffloding.git",
   "author": "Martin Marosi <marvusm.mmi@gmail.com>",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {},
   "dependencies": {
     "@openshift/dynamic-plugin-sdk": "^5.0.1",


### PR DESCRIPTION
## Summary                                                                                                                                                                 
                                                                                                                                                                             
  Fixes npm publish failure for scoped packages by adding `publishConfig.access: "public"`.                                                                                  
                                                                                                                                                                             
  ## Problem                                                                                                                                                                 
                                                          
  Release job failed with: Not Found - PUT https://registry.npmjs.org/@scalprum%2fcore - Not found `@scalprum/core@0.9.1` is not in this registry.                                                                                                                            
   
  Scoped packages (`@scalprum/*`) default to `restricted` (private) visibility. Without explicit `"access": "public"` in package.json, npm rejects the publish.              
                                                                                                                                                                             
  ## Changes                                                                                                                                                                 
                                                                                                                                                                             
  Added to all 3 packages:                                
  - `packages/core/package.json`
  - `packages/react-core/package.json`                                                                                                                                       
  - `packages/react-test-utils/package.json`                                                                                                                                 
                                                                                                                                                                             
  ```json                                                                                                                                                                    
  "publishConfig": {                                                                                                                                                         
    "access": "public"                                                                                                                                                       
  }                                                                                                                                                                          
   ```
  **Context**                                                                                                                                                                    
                                                          
  Working package @redhat-cloud-services/rbac-client has this config, confirming the requirement.                                                                            
                                                          
  Per npm docs, scoped packages require explicit public access declaration.                                                                                                  
                                                          
  **Related**                                                                                                                                                                    
                                                          
  - RHCLOUD-47582                                                                                                                                                            
  - Follow-up to #166 (OIDC trusted publishing)