### PR TITLE
fix(ci): enable npm OIDC trusted publishing with npm 11 upgrade

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -18,6 +18,19 @@ runs:
       with:
         node-version-file: '.nvmrc'
         registry-url: 'https://registry.npmjs.org'
+    - name: Show node/npm versions
+      shell: bash
+      run: |
+        echo "=== Node.js version ==="
+        node --version
+        echo "=== npm version (before upgrade) ==="
+        npm --version
+    - name: Update npm for trusted publishing support
+      shell: bash
+      run: |
+        npm install -g npm@11
+        echo "=== npm version (after upgrade) ==="
+        npm --version
     - uses: './.github/actions/node-cache'
     - name: Install deps
       shell: bash

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "main": "./index.js",
   "module": "./esm/index.js",
   "typings": "./index.d.ts",
-  "repository": "https://github.com/scalprum/scaffloding.git",
+  "repository": "https://github.com/scalprum/scaffolding.git",
   "author": "Martin Marosi <marvusm.mmi@gmail.com>",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -5,7 +5,7 @@
   "main": "./index.js",
   "module": "./esm/index.js",
   "typings": "./index.d.ts",
-  "repository": "https://github.com/scalprum/scaffloding.git",
+  "repository": "https://github.com/scalprum/scaffolding.git",
   "author": "Martin Marosi <marvusm.mmi@gmail.com>",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/react-test-utils/package.json
+++ b/packages/react-test-utils/package.json
@@ -5,7 +5,7 @@
   "main": "./index.js",
   "module": "./esm/index.js",
   "typings": "./index.d.ts",
-  "repository": "https://github.com/scalprum/scaffloding.git",
+  "repository": "https://github.com/scalprum/scaffolding.git",
   "author": "Martin Marosi <marvusm.mmi@gmail.com>",
   "license": "Apache-2.0",
   "publishConfig": {


### PR DESCRIPTION
OIDC trusted publishing requires npm version 11.5.1+