### PR TITLE
docs: fix corepack doc for npm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,11 @@ Before running any npm commands:
 
 2. **Enable corepack** (one-time):
    ```bash
-   corepack enable
+   corepack enable npm
    ```
    
    This allows npm 11.14.1 to be used automatically via the `packageManager` field without affecting global npm.
+   `corepack enable` only enables yarn and pnpm by default. npm shims excluded because npm ships with Node.js separately.
 
 ## Why npm 11.14.1?
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ This project requires Node.js 20+ with npm 11.14.1+ for npm OIDC trusted publish
 2. **Setup Node.js and npm:**
    ```bash
    nvm use              # Install/use Node 20 from .nvmrc
-   corepack enable      # Enable npm 11.14.1 via packageManager field
+   corepack enable npm     # Enable npm 11.14.1 via packageManager field
    ```
 
 3. **Install dependencies:**

--- a/package.json
+++ b/package.json
@@ -2,6 +2,12 @@
   "name": "@scalprum/source",
   "version": "1.0.6",
   "license": "MIT",
+  "private": true,
+  "packageManager": "npm@11.14.1",
+  "engines": {
+    "node": ">=20.0.0",
+    "npm": ">=11.14.1"
+  },
   "workspaces": [
     "packages/*"
   ],
@@ -18,12 +24,6 @@
     "lint": "nx run-many -t lint",
     "typecheck": "nx run-many -t typecheck",
     "postinstall": "rm -rf .webpack-cache"
-  },
-  "private": true,
-  "packageManager": "npm@11.14.1",
-  "engines": {
-    "node": ">=20.0.0",
-    "npm": ">=11.14.1"
   },
   "dependencies": {
     "@emotion/react": "11.11.1",


### PR DESCRIPTION
`corepack enable` only enables yarn and pnpm by default. Therefore `corepack enable npm` needed. npm shims excluded because npm ships with Node.js separately.

`corepack enable npm` needs to be run once per node version, so workflow is:

```sh
# check node version required by project
cat .nvmrc
# check current node version
node --version
# enable required node version
nvm use 

# check npm version required by project
grep packageManager package.json
# check current npm version
npm --version
# enable required npm version
corepack enable npm
```
