### PR TITLE
chore: update workspace dep ranges for SDK v8 release

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@openshift/dynamic-plugin-sdk": "^8.0.0",
-    "@scalprum/core": "^0.9.1",
+    "@scalprum/core": "^0.10.0",
     "lodash": "^4.17.0"
   },
   "peerDependencies": {

--- a/packages/react-test-utils/package.json
+++ b/packages/react-test-utils/package.json
@@ -14,8 +14,8 @@
   "scripts": {},
   "dependencies": {
     "@openshift/dynamic-plugin-sdk": "^8.0.0",
-    "@scalprum/core": "^0.9.1",
-    "@scalprum/react-core": "^0.11.2",
+    "@scalprum/core": "^0.10.0",
+    "@scalprum/react-core": "^0.12.0",
     "tslib": "^2.6.2",
     "whatwg-fetch": "^3.6.0"
   },


### PR DESCRIPTION
## Summary

- `@scalprum/core` range: `^0.9.1` → `^0.10.0` in react-core and react-test-utils
- `@scalprum/react-core` range: `^0.11.2` → `^0.12.0` in react-test-utils

## Why

After the SDK v5 → v8 bump (#174), `@scalprum/core` will release as `0.10.0` (minor bump from conventional commits). The old `^0.9.1` range doesn't cover `0.10.0` because semver `^0.x` only allows patch-level changes. This causes `nx release` to fail with `preserveMatchingDependencyRanges` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)