### PR TITLE
chore: disable preserveMatchingDependencyRanges for nx release

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -85,6 +85,7 @@
       "preVersionCommand": "npx nx run-many -t build",
       "conventionalCommits": true,
       "preserveLocalDependencyProtocols": false,
+      "preserveMatchingDependencyRanges": false,
       "versionActionsOptions": {
         "skipLockFileUpdate": false
       }


### PR DESCRIPTION
## Summary

Disables the `preserveMatchingDependencyRanges` option in nx.json release config.

## Why

Nx 22 defaults this to `true`, which blocks `nx release` when workspace packages use `^0.x` semver ranges. In semver, `^0.9.1` only covers patch bumps (`0.9.x`), so a minor bump to `0.10.0` falls outside the range and nx refuses to proceed. Since scalprum is pre-1.0, this would require manual range updates before every minor release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)