### PR TITLE
chore: enforce commit scope validation and PR title checks

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": ["@commitlint/config-conventional"],
-  "rules": {
-    "body-max-line-length": [0]
-  }
-}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: './.github/actions/setup-environment'
+      - name: Test commitlint config
+        run: npx jest --config=commitlint.jest.config.js
       - name: Validate current commit (last commit) with commitlint
         if: github.event_name == 'push'
         run: npx commitlint --last --verbose

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,24 @@
+name: PR title lint
+permissions:
+  contents: read
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, edited, reopened]
+
+jobs:
+  pr-title-lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: './.github/actions/setup-environment'
+      - name: Validate PR title with commitlint
+        shell: bash
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: echo "$PR_TITLE" | npx commitlint --verbose

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,89 @@
-export default {extends: ['@commitlint/config-conventional']};
+const { execSync } = require('child_process');
+
+function getNxProjects() {
+  try {
+    const output = execSync('npx nx show projects --json', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return JSON.parse(output);
+  } catch {
+    console.warn(
+      'commitlint: Could not load Nx projects — scope validation skipped.'
+    );
+    return null;
+  }
+}
+
+const validProjects = getNxProjects();
+
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'scope-case': [0],
+    'body-max-length': [0],
+    'body-max-line-length': [0],
+    'header-max-length': [2, 'always', 256],
+    'scope-full-name-for-versioning': [2, 'always'],
+  },
+  plugins: [
+    {
+      rules: {
+        'scope-full-name-for-versioning': (parsed) => {
+          if (!validProjects) {
+            return [true];
+          }
+
+          const { type, header, notes } = parsed;
+
+          // Detect breaking change: header `!:` marker OR BREAKING CHANGE footer
+          const isBreaking =
+            !!(header && header.includes('!:')) ||
+            !!(notes && notes.some((n) => n.title === 'BREAKING CHANGE'));
+          const requiresFullScope = type === 'feat' || isBreaking;
+
+          if (!requiresFullScope) {
+            return [true];
+          }
+
+          // Use parsed scope if available, otherwise extract from raw header
+          // (fallback handles parsers that don't support the ! marker)
+          let scope = parsed.scope;
+          if (!scope && header) {
+            const match = header.match(/^\w+\(([^)]+)\)/);
+            if (match) {
+              scope = match[1];
+            }
+          }
+
+          if (!scope) {
+            const commitType = isBreaking ? 'breaking (!)/feat' : 'feat';
+            return [
+              false,
+              `Scope required for ${commitType} commits.\n` +
+                `Use: ${type}(@scalprum/core): ...`,
+            ];
+          }
+
+          const projectSet = new Set(validProjects);
+          const scopes = scope.split(',');
+
+          for (const s of scopes) {
+            if (!projectSet.has(s)) {
+              const commitType = isBreaking ? 'breaking (!)/feat' : 'feat';
+              const hint = s.startsWith('@scalprum/')
+                ? `Project "${s}" not found. Run: npx nx show projects`
+                : `Use full project name like: ${type}(@scalprum/core)${isBreaking ? '!' : ''}: ...`;
+              return [
+                false,
+                `Scope "${s}" must be a full Nx project name for ${commitType} commits.\n${hint}`,
+              ];
+            }
+          }
+
+          return [true];
+        },
+      },
+    },
+  ],
+};

--- a/commitlint.config.test.js
+++ b/commitlint.config.test.js
@@ -1,0 +1,164 @@
+const { default: lint } = require('@commitlint/lint');
+const config = require('./commitlint.config');
+
+// Use the conventional-commits parser opts that support the ! breaking marker.
+// In production, commitlint loads these from @commitlint/config-conventional.
+const parserOpts = {
+  headerPattern: /^(\w*)(?:\((.*)\))?!?: (.*)$/,
+  headerCorrespondence: ['type', 'scope', 'subject'],
+};
+
+const lintMessage = (message) =>
+  lint(message, config.rules, { plugins: config.plugins, parserOpts });
+
+describe('commitlint scope-full-name-for-versioning', () => {
+  describe('valid commits', () => {
+    it('feat with full project name', async () => {
+      const result = await lintMessage('feat(@scalprum/react-core): add endpoint');
+      expect(result.valid).toBe(true);
+    });
+
+    it('fix with full project name', async () => {
+      const result = await lintMessage('fix(@scalprum/react-test-utils): handle error');
+      expect(result.valid).toBe(true);
+    });
+
+    it('breaking with full project name (! marker)', async () => {
+      const result = await lintMessage('feat(@scalprum/react-core)!: remove v1');
+      expect(result.valid).toBe(true);
+    });
+
+    it('breaking with full project name (BREAKING CHANGE footer)', async () => {
+      const result = await lintMessage(
+        'feat(@scalprum/react-core): remove v1\n\nBREAKING CHANGE: removes v1 API'
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('multiple scopes comma-separated', async () => {
+      const result = await lintMessage(
+        'feat(@scalprum/core,@scalprum/react-core): shared change'
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('chore with short scope (no version impact)', async () => {
+      const result = await lintMessage('chore(core): update docs');
+      expect(result.valid).toBe(true);
+    });
+
+    it('docs with short scope (no version impact)', async () => {
+      const result = await lintMessage('docs(readme): add examples');
+      expect(result.valid).toBe(true);
+    });
+
+    it('chore with area scope (deps)', async () => {
+      const result = await lintMessage('chore(deps): add new dep');
+      expect(result.valid).toBe(true);
+    });
+
+    it('chore with area scope (ci)', async () => {
+      const result = await lintMessage('chore(ci): update workflow');
+      expect(result.valid).toBe(true);
+    });
+
+    it('chore with no scope', async () => {
+      const result = await lintMessage('chore: maintenance');
+      expect(result.valid).toBe(true);
+    });
+
+    it('build-utils project name (non-release package, unscoped nx name)', async () => {
+      const result = await lintMessage('feat(build-utils): add executor');
+      expect(result.valid).toBe(true);
+    });
+
+    it('core project name', async () => {
+      const result = await lintMessage('fix(@scalprum/core): fix interceptor');
+      expect(result.valid).toBe(true);
+    });
+
+    it('fix with short scope (allowed)', async () => {
+      const result = await lintMessage('fix(react-core): handle error');
+      expect(result.valid).toBe(true);
+    });
+
+    it('fix with no scope (allowed)', async () => {
+      const result = await lintMessage('fix: global change');
+      expect(result.valid).toBe(true);
+    });
+
+    it('fix with deps scope (dependabot)', async () => {
+      const result = await lintMessage('fix(deps): bump axios to 1.18.0');
+      expect(result.valid).toBe(true);
+    });
+
+    it('fix with deps-dev scope (dependabot)', async () => {
+      const result = await lintMessage('fix(deps-dev): bump webpack to 5.1.0');
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('invalid commits', () => {
+    it('feat with short scope', async () => {
+      const result = await lintMessage('feat(react-core): add endpoint');
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toContain('must be a full Nx project name');
+      expect(result.errors[0].message).toContain('Use full project name like');
+    });
+
+    it('breaking chore with short scope (! marker)', async () => {
+      const result = await lintMessage('chore(react-core)!: breaking change');
+      expect(result.valid).toBe(false);
+    });
+
+    it('breaking chore with short scope (BREAKING CHANGE footer)', async () => {
+      const result = await lintMessage(
+        'chore(react-core): breaking change\n\nBREAKING CHANGE: removes old API'
+      );
+      expect(result.valid).toBe(false);
+    });
+
+    it('breaking type! with short scope', async () => {
+      const result = await lintMessage('fix(react-core)!: breaking fix');
+      expect(result.valid).toBe(false);
+    });
+
+    it('comma-separated with one invalid scope', async () => {
+      const result = await lintMessage(
+        'feat(@scalprum/react-core,react-test-utils): mixed scopes'
+      );
+      expect(result.valid).toBe(false);
+    });
+
+    it('feat with invented project name', async () => {
+      const result = await lintMessage('feat(@scalprum/nonexistent): add feature');
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toContain('Project');
+      expect(result.errors[0].message).toContain('not found');
+    });
+
+    it('feat with no scope', async () => {
+      const result = await lintMessage('feat: global change');
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toContain('Scope required');
+    });
+
+    it('breaking with no scope', async () => {
+      const result = await lintMessage('fix!: breaking fix');
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toContain('Scope required');
+    });
+
+    it('feat with area scope (deps)', async () => {
+      const result = await lintMessage('feat(deps): add new dep');
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toContain('must be a full Nx project name');
+    });
+
+    it('feat with area scope (ci)', async () => {
+      const result = await lintMessage('feat(ci): update workflow');
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toContain('must be a full Nx project name');
+    });
+  });
+});

--- a/commitlint.jest.config.js
+++ b/commitlint.jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testMatch: ['**/commitlint.config.test.js'],
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.js$': ['babel-jest', { presets: [['@babel/preset-env', { targets: { node: 'current' } }]] }],
+  },
+  transformIgnorePatterns: ['node_modules/(?!(@commitlint)/)'],
+};

--- a/nx.json
+++ b/nx.json
@@ -75,6 +75,9 @@
   "release": {
     "projects": ["@scalprum/core", "@scalprum/react-core", "@scalprum/react-test-utils"],
     "projectsRelationship": "independent",
+    "conventionalCommits": {
+      "useCommitScope": true
+    },
     "version": {
       "git": {
         "commit": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "husky": "^8.0.3",
         "jest": "^30.0.5",
         "jest-environment-jsdom": "^30.0.5",
-        "jest-environment-node": "^29.4.1",
+        "jest-environment-node": "^30.0.5",
         "jest-util": "^30.0.5",
         "npm-run-all": "^4.1.5",
         "nx": "22.7.5",
@@ -20536,25 +20536,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jest-config/node_modules/jest-environment-node": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
-      "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/fake-timers": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-config/node_modules/pretty-format": {
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
@@ -20857,287 +20838,22 @@
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
-      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+      "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/types": "^29.6.3",
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "jest-mock": "^29.7.0",
-        "jest-util": "^29.7.0"
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/@jest/environment": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
-      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "jest-mock": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/@jest/fake-timers": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
-      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@sinonjs/fake-timers": "^10.0.2",
-        "@types/node": "*",
-        "jest-message-util": "^29.7.0",
-        "jest-mock": "^29.7.0",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-environment-node/node_modules/@sinonjs/fake-timers": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.0"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-environment-node/node_modules/jest-message-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.3",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/jest-mock": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-environment-node/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-haste-map": {
@@ -21665,25 +21381,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/jest-runner/node_modules/jest-environment-node": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
-      "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/fake-timers": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
     },
     "node_modules/jest-runner/node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "husky": "^8.0.3",
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.0.5",
-    "jest-environment-node": "^29.4.1",
+    "jest-environment-node": "^30.0.5",
     "npm-run-all": "^4.1.5",
     "nx": "22.7.5",
     "prettier": "^3.1.0",


### PR DESCRIPTION
**Summary**

  Port commit scope validation from `javascript-clients` to enforce full Nx project names (`@scalprum/core`, `@scalprum/react-core`, `@scalprum/react-test-utils`) on `feat` and breaking commits. Prevents semver bump silently capped to patch when scope mismatches and major version bump of shared package cascading to all packages.

  - Consolidate commitlint config + add scope-full-name-for-versioning rule with dynamic project list
  - Unit tests (26 passing) for all validation paths
  - Set `useCommitScope: true` explicit in `nx.json` (default)
  - Add `.github/workflows/pr-title.yaml` to catch violations before merge
  - Wire commitlint config tests into CI

  **Fixes**

  [RHCLOUD-49975](https://redhat.atlassian.net/browse/RHCLOUD-49975)

  **Test plan**

  - npx jest --config=commitlint.jest.config.js — 26/26 pass
  - echo "feat(core): ..." | npx commitlint — fails ✖
  - echo "feat(@scalprum/core): ..." | npx commitlint — passes ✔
  - npx nx release version --dry-run --verbose — no unexpected cascades