### PR TITLE
chore(security): enforce 2-day package cooldown

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,6 @@ legacy-peer-deps=false
 
 # Enforce engine requirements from package.json
 engine-strict=true
+
+# https://source.redhat.com/departments/strategy_and_operations/it/it_information_security/blog/setting_up_package_cooldown_and_stopping_malware
+min-release-age=2


### PR DESCRIPTION
Enforce 2-day package cooldown as per infosec guidance. 
https://source.redhat.com/departments/strategy_and_operations/it/it_information_security/blog/setting_up_package_cooldown_and_stopping_malware