### PR TITLE
chore(deps): bump react-router-dom to ^7.18.2 to close react-router vuln chain in test-app

### DIFF
--- a/examples/test-app/jest.config.ts
+++ b/examples/test-app/jest.config.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 module.exports = {
+  setupFiles: ['<rootDir>/jest.setup.ts'],
   displayName: 'shell',
   preset: '../../jest.preset.js',
   transform: {

--- a/examples/test-app/jest.setup.ts
+++ b/examples/test-app/jest.setup.ts
@@ -1,0 +1,10 @@
+import { TextEncoder, TextDecoder } from 'node:util';
+
+// jsdom's test environment doesn't expose these globally, but react-router-dom
+// v7 references them at module load time.
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = TextEncoder;
+}
+if (typeof global.TextDecoder === 'undefined') {
+  global.TextDecoder = TextDecoder as typeof global.TextDecoder;
+}

--- a/federation-cdn-mock/package-lock.json
+++ b/federation-cdn-mock/package-lock.json
@@ -25,52 +25,22 @@
         "webpack-cli": "^5.1.4"
       }
     },
-    "../../dist/packages/build-tools": {
-      "name": "@scalprum/build-tools",
-      "version": "0.0.1",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@module-federation/enhanced": "^0.1.2",
-        "@openshift/dynamic-plugin-sdk-webpack": "^4.0.2",
-        "lodash": "^4.17.21",
-        "semver": "^7.6.0",
-        "tslib": "^2.6.2",
-        "webpack": "^5.91.0",
-        "yup": "^1.4.0"
-      }
-    },
-    "../dist/packages/build-tools": {
-      "name": "@scalprum/build-tools",
-      "version": "0.0.1",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@module-federation/enhanced": "^0.1.2",
-        "@openshift/dynamic-plugin-sdk-webpack": "^4.0.2",
-        "lodash": "^4.17.21",
-        "semver": "^7.6.0",
-        "tslib": "^2.6.2",
-        "webpack": "^5.91.0",
-        "yup": "^1.4.0"
-      }
-    },
     "../dist/packages/core": {
       "name": "@scalprum/core",
-      "version": "0.10.1",
+      "version": "0.10.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openshift/dynamic-plugin-sdk": "^8.0.0",
+        "@openshift/dynamic-plugin-sdk": "^9.1.0",
         "tslib": "^2.6.2"
       }
     },
     "../dist/packages/react-core": {
       "name": "@scalprum/react-core",
-      "version": "0.13.1",
+      "version": "0.13.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openshift/dynamic-plugin-sdk": "^8.0.0",
-        "@scalprum/core": "^0.10.1",
+        "@openshift/dynamic-plugin-sdk": "^9.1.0",
+        "@scalprum/core": "^0.10.3",
         "lodash": "^4.17.0"
       },
       "devDependencies": {
@@ -81,50 +51,6 @@
       "peerDependencies": {
         "react": ">=17.0.0 <20.0.0",
         "react-dom": ">=17.0.0 <20.0.0"
-      }
-    },
-    "../packages/core": {
-      "name": "@scalprum/core",
-      "version": "0.8.3",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@openshift/dynamic-plugin-sdk": "^5.0.1",
-        "tslib": "^2.6.2"
-      }
-    },
-    "../packages/react-core": {
-      "name": "@scalprum/react-core",
-      "version": "0.10.2",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@openshift/dynamic-plugin-sdk": "^5.0.1",
-        "@scalprum/core": "^0.8.3",
-        "lodash": "^4.17.0"
-      },
-      "devDependencies": {
-        "@types/react": "^18.3.0",
-        "@types/react-dom": "^18.3.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0 || >=17.0.0 || ^18.0.0",
-        "react-dom": ">=16.8.0 || >=17.0.0 || ^18.0.0"
-      }
-    },
-    "../scaffolding/dist/packages/build-tools": {
-      "name": "@scalprum/build-tools",
-      "version": "0.0.1",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@module-federation/enhanced": "^0.1.2",
-        "@openshift/dynamic-plugin-sdk-webpack": "^4.0.2",
-        "lodash": "^4.17.21",
-        "semver": "^7.6.0",
-        "tslib": "^2.6.2",
-        "webpack": "^5.91.0",
-        "yup": "^1.4.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-grid-layout": "^1.4.4",
-        "react-router-dom": "^6.30.3",
+        "react-router-dom": "^7.18.2",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -7681,15 +7681,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -27133,35 +27124,54 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/react-transition-group": {
@@ -28879,6 +28889,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-grid-layout": "^1.4.4",
-    "react-router-dom": "^6.30.3",
+    "react-router-dom": "^7.18.2",
     "tslib": "^2.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# Summary

Bumps `react-router-dom` from `^6.30.3` to `^7.18.2` in `examples/test-app` to close a transitive `react-router` vulnerability chain flagged by npm audit. Adds a `jsdom` polyfill for `TextEncoder`/`TextDecoder` globals that `react-router-dom` `v7` references at module load time.

No published package is affected. 

*Note: npm audit still flags a high-severity react-router finding (GHSA-qwww-vcr4-c8h2, "RSC Mode CSRF Bypass") even at latest 7.18.2. Advisory range 7.12.0–8.2.0, no upstream fix available yet. Not a regression from this PR — flagged on RHCLOUD-49989.

[RHCLOUD-49989](https://redhat.atlassian.net/browse/RHCLOUD-49989)